### PR TITLE
Added --debug flag for debug symbols.

### DIFF
--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -6,7 +6,8 @@ public final class Build: Command {
     public let signature: [Argument] = [
         Option(name: "run", help: ["Runs the project after building."]),
         Option(name: "clean", help: ["Cleans the project before building."]),
-        Option(name: "mysql", help: ["Links MySQL libraries."])
+        Option(name: "mysql", help: ["Links MySQL libraries."]),
+        Option(name: "debug", help: ["Builds with debug symbols."])
     ]
 
     public let help: [String] = [
@@ -39,11 +40,18 @@ public final class Build: Command {
             ]
         }
 
+        if arguments.flag("debug") {
+            buildFlags += [
+                "-Xswiftc",
+                "-g"
+            ]
+        }
+        
         let buildBar = console.loadingBar(title: "Building Project")
         buildBar.start()
 
         for (name, value) in arguments.options {
-            if ["clean", "run", "mysql"].contains(name) {
+            if ["clean", "run", "mysql", "debug"].contains(name) {
                 continue
             }
 


### PR DESCRIPTION
When I was trying to debug on the test server I got tired of constantly having to type `-Xswiftc -g` and added the `--debug` flag to my local copy and it seemed like this may be useful for others.

I'm also considering making a new command called `debug` that will be a little like `run` except it will setup the executable in lldb, instead of running it. What are your thoughts?