### PR TITLE
Bump swift version

### DIFF
--- a/.swift-version
+++ b/.swift-version
@@ -1,1 +1,1 @@
-3.0-GM-CANDIDATE
+3.0


### PR DESCRIPTION
This adds support for the final Swift 3 release, which is distributed with Xcode 8 in the App Store.