### PR TITLE
dynamic modulemap

### DIFF
--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -3,7 +3,7 @@ import Console
 import Foundation
 import VaporToolbox
 
-let version = "1.0.1"
+let version = "1.0.2"
 
 let terminal = Terminal(arguments: CommandLine.arguments)
 

--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -128,7 +128,7 @@ public final class Build: Command {
         }
 
         if arguments.options["run"]?.bool == true {
-            let args = arguments.filter { !["--clean", "--run"].contains($0) }
+            let args = arguments.filter { !["--clean", "--run", "--modulemap=false"].contains($0) }
             let run = Run(console: console)
             try run.run(arguments: args)
         }

--- a/Sources/VaporToolbox/Xcode.swift
+++ b/Sources/VaporToolbox/Xcode.swift
@@ -51,6 +51,12 @@ public final class Xcode: Command {
             }
         }
 
+        do {
+            _ = try console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "rm -rf Packages/CLibreSSL-1.*/Sources/CLibreSSL/include/module.modulemap"])
+        } catch {
+            console.warning("Could not remove module map.")
+        }
+
         let argsArray = ["package", "generate-xcodeproj"] + buildFlags
 
         do {

--- a/Tests/VaporToolboxTests/BuildTests.swift
+++ b/Tests/VaporToolboxTests/BuildTests.swift
@@ -14,7 +14,7 @@ class BuildTests: XCTestCase {
         let build = Build(console: console)
 
         do {
-            try build.run(arguments: [])
+            try build.run(arguments: ["--modulemap=false"])
             XCTAssertEqual(console.outputBuffer, [
                 "No Packages folder, fetch may take a while...",
                 "Fetching Dependencies [Done]",
@@ -35,7 +35,7 @@ class BuildTests: XCTestCase {
         let build = Build(console: console)
 
         do {
-            try build.run(arguments: ["--clean"])
+            try build.run(arguments: ["--clean", "--modulemap=false"])
             XCTAssertEqual(console.outputBuffer, [
                 "Cleaning [Done]",
                 "No Packages folder, fetch may take a while...",
@@ -63,7 +63,7 @@ class BuildTests: XCTestCase {
         ]
 
         do {
-            try build.run(arguments: ["--run"])
+            try build.run(arguments: ["--run", "--modulemap=false"])
             XCTAssertEqual(console.outputBuffer, [
                 "No Packages folder, fetch may take a while...",
                 "Fetching Dependencies [Done]",
@@ -88,7 +88,7 @@ class BuildTests: XCTestCase {
         let build = Build(console: console)
 
         do {
-            try build.run(arguments: ["--mysql"])
+            try build.run(arguments: ["--mysql", "--modulemap=false"])
             XCTAssertEqual(console.outputBuffer, [
                 "No Packages folder, fetch may take a while...",
                 "Fetching Dependencies [Done]",


### PR DESCRIPTION
This has the potential to greatly reduce build times on the command line by dynamically adding and removing a module map for `CLibreSSL`