### PR TITLE
Updates from original Dockerfile for Swift 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,16 @@
 
 FROM ubuntu:14.04
 
-ENV SWIFT_BRANCH development
+ENV SWIFT_BRANCH swift-3.0-release
 ARG SWIFT_VERSION
 ENV SWIFT_VERSION ${SWIFT_VERSION}
 ENV SWIFT_PLATFORM ubuntu14.04
 
-# Install related packages
+# Install related packages and set LLVM 3.6 as the compiler
 RUN apt-get update && \
-    apt-get install -y build-essential wget clang curl libedit-dev python2.7 python2.7-dev libicu52 rsync libxml2 git && \
+    apt-get install -y build-essential wget clang-3.6 curl libedit-dev python2.7 python2.7-dev libicu52 rsync libxml2 git && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -19,12 +21,12 @@ RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
     gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
 
 # Install Swift Ubuntu 14.04 Snapshot
-RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
-    SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/swift-$SWIFT_VERSION/$SWIFT_ARCHIVE_NAME.tar.gz && \
-    wget -q $SWIFT_URL && \
-    wget -q $SWIFT_URL.sig && \
+RUN SWIFT_ARCHIVE_NAME=$SWIFT_VERSION-$SWIFT_PLATFORM && \
+    SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_ARCHIVE_NAME.tar.gz && \
+    wget $SWIFT_URL && \
+    wget $SWIFT_URL.sig && \
     gpg --verify $SWIFT_ARCHIVE_NAME.tar.gz.sig && \
-    tar -xzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
+    tar -xvzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
     rm -rf $SWIFT_ARCHIVE_NAME* /tmp/* /var/tmp/*
 
 # Set Swift Path


### PR DESCRIPTION
Hi.

Currently `vapor docker build` fails to build any images due to Dockerfile being outdated. This PR fixes this.