### PR TITLE
create /usr/local/bin if it does not already exist

### DIFF
--- a/Sources/VaporToolbox/SelfInstall.swift
+++ b/Sources/VaporToolbox/SelfInstall.swift
@@ -37,6 +37,17 @@ public final class SelfInstall: Command {
         let current = file.trim()
 
         let command = [current, "/usr/local/bin/vapor"]
+        
+        do {
+            _ = try console.backgroundExecute(program: "mkdir", arguments: ["-p", "/usr/local/bin"])
+        } catch ConsoleError.backgroundExecute {
+            console.warning("Failed to create /usr/local/bin, trying sudo")
+            do {
+                _ = try console.backgroundExecute(program: "sudo", arguments: ["mkdir", "-p", "/usr/local/bin"])
+            } catch ConsoleError.backgroundExecute {
+                throw ToolboxError.general("Installation Failed. Could not create /usr/local/bin")
+            }
+        }
 
         do {
             _ = try console.backgroundExecute(program: "mv", arguments: command)


### PR DESCRIPTION
I had tried to install Vapor Toolbox immediately after doing a fresh install of Sierra and it failed due to /usr/local/bin not existing yet.