### PR TITLE
Add command to create new preparation files from template.

### DIFF
--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -45,7 +45,8 @@ do {
             "Commands to help manage a Docker image."
         ]),
         Group(id: "prepare", commands: [
-            PrepareAdd(console: terminal)
+            PrepareAdd(console: terminal),
+            PrepareList(console: terminal)
         ], help: [
             "Commands related to database migrations."
         ])

--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -45,9 +45,7 @@ do {
             "Commands to help manage a Docker image."
         ]),
         Group(id: "prepare", commands: [
-            PrepareAdd(console: terminal),
-//            PrepareRun(console: terminal),        // vapor run prepare
-//            PrepareRevert(console: terminal)      // vapor run prepare --revert
+            PrepareAdd(console: terminal)
         ], help: [
             "Commands related to database migrations."
         ])

--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -43,6 +43,13 @@ do {
             DockerEnter(console: terminal)
         ], help: [
             "Commands to help manage a Docker image."
+        ]),
+        Group(id: "prepare", commands: [
+            PrepareAdd(console: terminal),
+//            PrepareRun(console: terminal),        // vapor run prepare
+//            PrepareRevert(console: terminal)      // vapor run prepare --revert
+        ], help: [
+            "Commands related to database migrations."
         ])
     ], arguments: Array(iterator), help: [
         "Join our Slack if you have questions, need help,",

--- a/Sources/VaporToolbox/PrepareAdd.swift
+++ b/Sources/VaporToolbox/PrepareAdd.swift
@@ -64,12 +64,10 @@ public final class PrepareAdd: Command {
             "import Fluent\n\n",
             "struct \(preparationName): Preparation {\n\n",
             "    static func prepare(_ database: Database) throws {\n",
-            "        let sql = \"select 1\"\n",
-            "        _ = try database.driver.raw(sql, [])\n",
+            "        // modify the data or squema\n",
             "    }\n\n",
             "    static func revert(_ database: Database) throws {\n",
-            "        let sql = \"select 1\"\n",
-            "        _ = try database.driver.raw(sql, [])\n",
+            "        // revert changes from prepare if possible\n",
             "    }\n\n",
             "}\n"
         ]

--- a/Sources/VaporToolbox/PrepareAdd.swift
+++ b/Sources/VaporToolbox/PrepareAdd.swift
@@ -17,6 +17,10 @@ public final class PrepareAdd: Command {
     }
 
     public func run(arguments: [String]) throws {
+        if arguments.count < 2 {
+            throw ToolboxError.general("Missing preparation name. Usage: vapor prepare add MyFirstPreparation")
+        }
+        
         let preparationsFolder = "./Sources/App/Preparations"
 
         do {
@@ -35,10 +39,6 @@ public final class PrepareAdd: Command {
             _ = try console.backgroundExecute(program: "mkdir", arguments: ["-p", preparationsFolder])
         } catch ConsoleError.backgroundExecute(_) {
             throw ToolboxError.general("Failed to create preparations folder (\(preparationsFolder)).")
-        }
-
-        if arguments.count < 2 {
-            throw ToolboxError.general("Missing preparation name. Usage: vapor prepare add MyFirstPreparation")
         }
 
         let formatter = DateFormatter()

--- a/Sources/VaporToolbox/PrepareAdd.swift
+++ b/Sources/VaporToolbox/PrepareAdd.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Console
+
+public final class PrepareAdd: Command {
+    public let id = "add"
+
+    public let signature: [Argument] = []
+
+    public let help: [String] = [
+        "Create new database preparation file."
+    ]
+
+    public let console: ConsoleProtocol
+
+    public init(console: ConsoleProtocol) {
+        self.console = console
+    }
+
+    public func run(arguments: [String]) throws {
+        let preparationsFolder = "./Sources/App/Preparations"
+
+        do {
+            _ = try console.backgroundExecute(program: "ls", arguments: ["./Sources/App/main.swift"])
+        } catch ConsoleError.backgroundExecute(_) {
+            throw ToolboxError.general("Invalid Vapor template: could not find Sources/App/main.swift file")
+        }
+
+        do {
+            _ = try console.backgroundExecute(program: "ls", arguments: [preparationsFolder])
+        } catch ConsoleError.backgroundExecute(_) {
+            console.warning("No preparations folder found (\(preparationsFolder)). Creating now...")
+        }
+
+        do {
+            _ = try console.backgroundExecute(program: "mkdir", arguments: ["-p", preparationsFolder])
+        } catch ConsoleError.backgroundExecute(_) {
+            throw ToolboxError.general("Failed to create preparations folder (\(preparationsFolder)).")
+        }
+
+        if arguments.count < 2 {
+            throw ToolboxError.general("Missing preparation name. Usage: vapor prepare add MyFirstPreparation")
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd_HHmm"
+        let dateStr = formatter.string(from: Date())
+
+        let preparationName = "Preparation\(arguments[1])"
+        let fileName = "\(preparationsFolder)/\(dateStr)_\(preparationName).swift"
+
+        let template = preparationTemplate(preparationName: preparationName).joined()
+
+        do {
+            try template.write(toFile: fileName, atomically: true, encoding: .utf8)
+        } catch {
+            throw ToolboxError.general("Could not write preparation file \(fileName)")
+        }
+
+        console.info("Preparation created: \(fileName)")
+    }
+
+    private func preparationTemplate(preparationName: String) -> [String] {
+        return [
+            "import Fluent\n\n",
+            "struct \(preparationName): Preparation {\n\n",
+            "    static func prepare(_ database: Database) throws {\n",
+            "        let sql = \"select 1\"\n",
+            "        _ = try database.driver.raw(sql, [])\n",
+            "    }\n\n",
+            "    static func revert(_ database: Database) throws {\n",
+            "        let sql = \"select 1\"\n",
+            "        _ = try database.driver.raw(sql, [])\n",
+            "    }\n\n",
+            "}\n"
+        ]
+    }
+
+}

--- a/Sources/VaporToolbox/PrepareList.swift
+++ b/Sources/VaporToolbox/PrepareList.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Console
+
+public final class PrepareList: Command {
+    public let id = "list"
+
+    public let signature: [Argument] = []
+
+    public let help: [String] = [
+        "Create new database preparation file."
+    ]
+
+    public let console: ConsoleProtocol
+
+    public init(console: ConsoleProtocol) {
+        self.console = console
+    }
+
+    public func run(arguments: [String]) throws {
+        try listPreparations()
+    }
+
+    private func listPreparations() throws {
+        do {
+            let preparations = try console.backgroundExecute(program: "ls", arguments: [preparationsFolder])
+            for preparation in preparations.components(separatedBy: CharacterSet.newlines) {
+                try checkPreparationStatus(filename: preparation)
+            }
+        } catch ConsoleError.backgroundExecute(_) {
+            console.warning("No preparations folder found (\(preparationsFolder)).")
+        }
+    }
+
+    private func checkPreparationStatus(filename: String) throws {
+//        filename.removeSubrange(filename.range(of: ".swift"))
+//        let parts = filename.components(separatedBy: "_")
+//        guard parts.count > 2 else {
+//            return
+//        }
+//        let timestamp = parts.dropFirst(2).joined(separator: "_")
+
+        print(filename)
+    }
+    
+}


### PR DESCRIPTION
This PR adds a new command `vapor prepare add [PreparationName]` to create a new preparation file from a template. Filenames are timestamped, so it is easy to know the order preparations should be executed in.

Vapor applications have subcommands for running and reverting preparations. However, it feels like those commands belong here in the toolbox. While that is up for discussion, I though adding this new command on the toolbox made more sense.

Future goals:
- After creating the new preparation file, ask the user if they would like to regenerate the Xcode project, if any.
- Use regex or another tool to add the new preparation to the list of preparations passed to Droplet in the `main.swift` application file. This list of preparations could me moved to a separate file for easier auto-generation. However, there is no easy way to determine the order for existing Model preparations. Maybe it should be encouraged to do those in timestamped files too instead of on the model field themselves.
