### PR TITLE
Fix Travis configuration to install swift 3.0.1 on virtual machine if not available (e.g. on Linux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: generic
 sudo: required
 dist: trusty
 osx_image: xcode8
+install:
+  - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+  - swiftenv install 3.0.1 || echo ""
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -sL swift.vapor.sh/ubuntu | bash; fi
 


### PR DESCRIPTION
Travis is not building correctly because Swift is not installed on its Linux virtual machines by default. This PR fixes this problem by installing Swift if necessary using [swiftenv](https://swiftenv.fuller.li/en/latest/).