### PR TITLE
Fixed cURL URL validation

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -98,31 +98,36 @@ public final class New: Command {
     */
     private func expand(template: String) throws -> String {
         // if valid URL, use it
-        guard try !isValid(url: template) else { return template }
+        guard !isValid(url: template) else { return template }
         // `/` indicates `owner/repo`
         guard !template.contains("/") else { return "https://github.com/" + template }
         // no '/' indicates vapor default
         let direct = "https://github.com/vapor/" + template
-        guard try !isValid(url: direct) else { return direct }
+        guard !isValid(url: direct) else { return direct }
         // invalid url attempts `-template` suffix
         return direct + "-template"
     }
 
-    private func isValid(url: String) throws -> Bool {
-        // http://stackoverflow.com/a/6136861/2611971
-        let result = try console.backgroundExecute(
-            program: "curl",
-            arguments: [
-                "-o",
-                "/dev/null",
-                "--silent",
-                "--head",
-                "--write-out",
-                "'%{http_code}\n'",
-                url
-            ]
-        )
-        return result.contains("200")
+    private func isValid(url: String) -> Bool {
+        do {
+            // http://stackoverflow.com/a/6136861/2611971
+            let result = try console.backgroundExecute(
+                program: "curl",
+                arguments: [
+                    "-o",
+                    "/dev/null",
+                    "--silent",
+                    "--head",
+                    "--write-out",
+                    "'%{http_code}\\n'",
+                    url
+                ]
+            )
+            return result.contains("200")
+        } catch {
+            // yucky...
+            return false
+        }
     }
 
     public let asciiArt: [String] = [


### PR DESCRIPTION
The trick used to verify URLs with cURL will return the expected result and a non-success exit code. In our use case, this result is considered a "successful" execution, but the backgroundExecute function see's the non-success code and throws an error. A better, more long term approach would be an overload that ignores exit codes, but I'm not sure how doable that is.

Sources:
```
Bretts-MacBook-Pro:toolbox bretttoomey$ curl -o /dev/null --silent --head --write-out '%{http_code}\n' nodes-vapor/template
000
Bretts-MacBook-Pro:toolbox bretttoomey$ echo $?
6
```

Then, on the [libcurl website](https://curl.haxx.se/libcurl/c/libcurl-errors.html):
```
CURLE_COULDNT_RESOLVE_HOST (6)

Couldn't resolve host. The given remote host was not resolved.
```