### PR TITLE
New command: validate template URL without curl

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -1,12 +1,20 @@
 import Console
 import Foundation
 
+// source: https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
+fileprivate let gitURLPattern = "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?"
+
 public final class New: Command {
     public let id = "new"
 
-    // source: https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
-    public let regexForGitURL = try! NSRegularExpression(pattern: "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?",
-                                                          options: NSRegularExpression.Options.caseInsensitive)
+    
+    #if os(Linux)
+    public let gitURLRegex = try! RegularExpression(pattern: gitURLPattern,
+                                                       options: RegularExpression.Options.caseInsensitive)
+    #else
+    public let gitURLRegex = try! NSRegularExpression(pattern: gitURLPattern,
+                                                         options: NSRegularExpression.Options.caseInsensitive)
+    #endif
 
     public let defaultTemplate = "https://github.com/vapor/basic-template"
 
@@ -109,7 +117,7 @@ public final class New: Command {
     }
 
     private func isGitURL(_ url: String) throws -> Bool {
-        return regexForGitURL.numberOfMatches(in: url,
+        return gitURLRegex.numberOfMatches(in: url,
                                               options: [],
                                               range: NSRange(location: 0, length: url.characters.count)) == 1
     }

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -2,7 +2,7 @@ import Console
 import Foundation
 
 // source: https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
-fileprivate let gitURLPattern = "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?"
+fileprivate let gitURLPattern = "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)?(/)?"
 
 public final class New: Command {
     public let id = "new"
@@ -117,9 +117,8 @@ public final class New: Command {
     }
 
     private func isGitURL(_ url: String) throws -> Bool {
-        return gitURLRegex.numberOfMatches(in: url,
-                                              options: [],
-                                              range: NSRange(location: 0, length: url.characters.count)) == 1
+        let range = NSRange(location: 0, length: url.characters.count)
+        return gitURLRegex.numberOfMatches(in: url, options: [], range: range) == 1
     }
 
     public let asciiArt: [String] = [

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -1,7 +1,12 @@
 import Console
+import Foundation
 
 public final class New: Command {
     public let id = "new"
+
+    // source: https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
+    public let regexForGitURL = try! NSRegularExpression(pattern: "((git|ssh|http(s)?)|(git@[\\w\\.]+))(:(//)?)([\\w\\.@\\:/\\-~]+)(\\.git)(/)?",
+                                                          options: NSRegularExpression.Options.caseInsensitive)
 
     public let defaultTemplate = "https://github.com/vapor/basic-template"
 
@@ -93,36 +98,20 @@ public final class New: Command {
          foo/some-template => https://github.com/foo/some-template
          some-template => https://github.com/vapor/some-template
          some => https://github.com/vapor/some
-         if fails, attempts `-template` suffix
-         some => https://github.com/vapor/some-template
     */
     private func expand(template: String) throws -> String {
         // if valid URL, use it
-        guard try !isValid(url: template) else { return template }
+        guard try !isGitURL(template) else { return template }
         // `/` indicates `owner/repo`
         guard !template.contains("/") else { return "https://github.com/" + template }
         // no '/' indicates vapor default
-        let direct = "https://github.com/vapor/" + template
-        guard try !isValid(url: direct) else { return direct }
-        // invalid url attempts `-template` suffix
-        return direct + "-template"
+        return "https://github.com/vapor/" + template
     }
 
-    private func isValid(url: String) throws -> Bool {
-        // http://stackoverflow.com/a/6136861/2611971
-        let result = try console.backgroundExecute(
-            program: "curl",
-            arguments: [
-                "-o",
-                "/dev/null",
-                "--silent",
-                "--head",
-                "--write-out",
-                "'%{http_code}\n'",
-                url
-            ]
-        )
-        return result.contains("200")
+    private func isGitURL(_ url: String) throws -> Bool {
+        return regexForGitURL.numberOfMatches(in: url,
+                                              options: [],
+                                              range: NSRange(location: 0, length: url.characters.count)) == 1
     }
 
     public let asciiArt: [String] = [


### PR DESCRIPTION
This is an alternative take on the issue that #120 tackles.

Apart from the incorrect return code handling from curl (see #120), I think the template resolving behavior is not reasonable in the first place. It mashes together syntax validation issues with network issues, while an URL does not become invalid just because the server failed to respond once.

Therefore I propose to replace curl calls with actual URL syntax validation, as seen below.

Remarks:
- The last fallback that adds `-template` at the end is obsolete (will never reach this), so I removed this as well.
- The regex I used in the PR has another extra hidden plus: it adds support for Git URLs next to HTTP URLs.