### PR TITLE
New: perform shallow Git clone to avoid downloading history

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -35,7 +35,7 @@ public final class New: Command {
         cloneBar.start()
 
         do {
-            _ = try console.backgroundExecute(program: "git", arguments: ["clone", "\(template)", "\(name)"])
+            _ = try console.backgroundExecute(program: "git", arguments: ["clone", "--depth=1", "\(template)", "\(name)"])
             _ = try console.backgroundExecute(program: "rm", arguments: ["-rf", "\(name)/.git"])
             cloneBar.finish()
         } catch ConsoleError.backgroundExecute(_, let error, _) {


### PR DESCRIPTION
(This is #122 moved under the vapor organization.)

Currently the `new` command performs a deep clone of the template repository's master branch, wasting megabytes for the complete history that is deleted on the next step.

This PR adds an extra `--depth=1` argument to `git clone` to only download the latest state.