### PR TITLE
Run: fix package name parsing in projects with targets

### DIFF
--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -1,5 +1,6 @@
 import Console
 import Foundation
+import JSON
 
 public final class Run: Command {
     public let id = "run"
@@ -86,13 +87,10 @@ public final class Run: Command {
     private func extractName() throws -> String? {
         let dump = try console.backgroundExecute(program: "swift", arguments: ["package", "dump-package"])
 
-        let dumpSplit = dump.components(separatedBy: "\"name\": \"")
-
-        guard dumpSplit.count == 2 else {
+        guard let json = try? JSON.init(serialized: dump.bytes) else {
             return nil
         }
 
-        let nameSplit = dumpSplit[1].components(separatedBy: "\"")
-        return nameSplit.first
+        return json["name"]?.string
     }
 }

--- a/Tests/VaporToolboxTests/RunTests.swift
+++ b/Tests/VaporToolboxTests/RunTests.swift
@@ -1,78 +1,76 @@
-/*
 import XCTest
-@testable import VaporCLI
-
+@testable import VaporToolbox
 
 class RunTests: XCTestCase {
-
+    var console: TestConsole!
+    var command: Run!
+    
     // required by LinuxMain.swift
     static var allTests: [(String, (RunTests) -> () throws -> Void)] {
         return [
-            ("test_execute", test_execute),
-            ("test_execute_args", test_execute_args),
-            ("test_execute_name", test_execute_name),
-            ("test_execute_release", test_execute_release),
-            ("test_help", test_help),
+            ("testRunFailsWithNoInformation", testRunFailsWithNoInformation),
+            ("testRunNameResolution", testRunNameResolution),
+            ("testRunWithProvidedExec", testRunWithProvidedExec),
+            ("testRunWithProvidedName", testRunWithProvidedName),
+            ("testRunRelease", testRunRelease),
+            ("testRunArgumentPassthrough", testRunArgumentPassthrough)
         ]
     }
 
-
     override func setUp() {
-        TestSystem.reset()
+        console = TestConsole()
+        command = Run(console: console)
     }
-
 
     // MARK: Tests
-
-
-    func test_execute() {
+    func testRunFailsWithNoInformation() throws {
         do {
-            try Run.execute(with: [], in: TestSystem.shell)
-            XCTAssertEqual(TestSystem.log, [.ok(".build/debug/App ")])
-        } catch {
-            XCTFail("unexpected error")
+            try command.run(arguments: [])
+        } catch (let err) {
+            guard case ToolboxError.general(let message) = err else {
+                XCTFail("command.run was expected to throw a general ToolboxError")
+                throw err
+            }
+
+            XCTAssertEqual("Unable to determine package name.", message,
+                           "Unexpected error was returned from command.run")
+            return
         }
+        
+        XCTFail("command.run was expected to fail, but did not")
+    }
+    
+    func testRunNameResolution() throws {
+        console.backgroundExecuteOutputBuffer["swift package dump-package"] = "{\"dependencies\": [{\"url\": \"https://github.com/vapor/vapor.git\", \"version\": {\"lowerBound\": \"1.3.0\", \"upperBound\": \"1.3.9223372036854775807\"}}], \"exclude\": [\"Config\", \"Database\", \"Localization\", \"Public\", \"Resources\", \"Tests\"], \"name\": \"Hello\", \"targets\": []}"
+        try command.run(arguments: [])
+
+        // TODO: the safeguard in Run uses FileManager.default that cannot be faked in the test,
+        //       therefore the actual executed command cannot be tested.
+        XCTAssertEqual("Running Hello...", console.outputBuffer.last ?? "")
     }
 
-
-    func test_execute_args() {
-        do {
-            try Run.execute(with: ["foo", "-bar"], in: TestSystem.shell)
-            XCTAssertEqual(TestSystem.log, [.ok(".build/debug/App foo -bar")])
-        } catch {
-            XCTFail("unexpected error")
-        }
-    }
-
-
-    func test_execute_name() {
-        do {
-            try Run.execute(with: ["--name=foo", "-bar"], in: TestSystem.shell)
-            XCTAssertEqual(TestSystem.log, [.ok(".build/debug/foo -bar")])
-        } catch {
-            XCTFail("unexpected error")
-        }
-
-    }
-
-
-    func test_execute_release() {
-        do {
-            try Run.execute(with: ["--release", "-bar"], in: TestSystem.shell)
-            XCTAssertEqual(TestSystem.log, [.ok(".build/release/App -bar")])
-        } catch {
-            XCTFail("unexpected error")
-        }
         
     }
 
-
-    // FIXME: test exception code paths
-
-    
-    func test_help() {
-        XCTAssert(Run.help.count > 0)
+    func testRunWithProvidedExec() throws {
+        try command.run(arguments: ["--exec=Hello", "--name=Hello"])
+        XCTAssertTrue(console.executeBuffer.last?.contains(".build/debug/Hello") ?? false)
     }
-
+    
+    func testRunWithProvidedName() throws {
+        try command.run(arguments: ["--name=Hello"])
+        // TODO: the safeguard in Run uses FileManager.default that cannot be faked in the test,
+        //       therefore the actual executed command cannot be tested.
+        XCTAssertEqual("Running Hello...", console.outputBuffer.last ?? "")
+    }
+    
+    func testRunRelease() throws {
+        try command.run(arguments: ["--name=Hello", "--release"])
+        XCTAssertTrue(console.executeBuffer.last?.contains(".build/release/") ?? false)
+    }
+    
+    func testRunArgumentPassthrough() throws {
+        try command.run(arguments: ["--name=Hello", "--foo=bar"])
+        XCTAssertTrue(console.executeBuffer.last?.contains("--foo=bar") ?? false)
+    }
 }
- */

--- a/Tests/VaporToolboxTests/RunTests.swift
+++ b/Tests/VaporToolboxTests/RunTests.swift
@@ -10,6 +10,7 @@ class RunTests: XCTestCase {
         return [
             ("testRunFailsWithNoInformation", testRunFailsWithNoInformation),
             ("testRunNameResolution", testRunNameResolution),
+            ("testRunNameResolutionWithTargets", testRunNameResolutionWithTargets),
             ("testRunWithProvidedExec", testRunWithProvidedExec),
             ("testRunWithProvidedName", testRunWithProvidedName),
             ("testRunRelease", testRunRelease),
@@ -49,7 +50,13 @@ class RunTests: XCTestCase {
         XCTAssertEqual("Running Hello...", console.outputBuffer.last ?? "")
     }
 
+    func testRunNameResolutionWithTargets() throws {
+        console.backgroundExecuteOutputBuffer["swift package dump-package"] = "{\"dependencies\":[],\"exclude\":[],\"name\":\"MultiTargetApp\",\"targets\":[{\"dependencies\":[\"MultiTargetDependency\"],\"name\":\"App\"}]}"
+        try command.run(arguments: [])
         
+        // TODO: the safeguard in Run uses FileManager.default that cannot be faked in the test,
+        //       therefore the actual executed command cannot be tested.
+        XCTAssertEqual("Running MultiTargetApp...", console.outputBuffer.last ?? "")
     }
 
     func testRunWithProvidedExec() throws {


### PR DESCRIPTION
This PR resolves #129 by using proper JSON parsing instead of just splitting the output of `swift package dump-package`.

As an added bonus, the Run command is now covered by tests, as much as the current implementation details support it.