### PR TITLE
bootstrap.sh: use the real version number instead of hardcoding "current"

### DIFF
--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -3,6 +3,7 @@ import Console
 import Foundation
 import VaporToolbox
 
+// The toolbox bootstrap script replaces "master" during installation. Do not modify!
 let version = "master"
 let terminal = Terminal(arguments: CommandLine.arguments)
 

--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -3,8 +3,7 @@ import Console
 import Foundation
 import VaporToolbox
 
-let version = "1.0.3"
-
+let version = "master"
 let terminal = Terminal(arguments: CommandLine.arguments)
 
 var iterator = CommandLine.arguments.makeIterator()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,10 @@ cd vapor-toolbox;
 TAG=$(git describe --tags);
 git checkout $TAG > /dev/null 2>&1;
 
+cat Sources/Executable/main.swift | \
+    awk -v tag="$TAG" '/let version = "master"/ { printf "let version = \"%s\"", tag; next } 1' > .tmp && \
+    mv .tmp Sources/Executable/main.swift
+
 echo "Compiling...";
 swift build -c release > /dev/null;
 


### PR DESCRIPTION
This PR enhances the installer script to overwrite the hardcoded version in `Executable/main.swift` with the current Git tag description, i.e. the actual version number.

This resolves #126 and prevents any future confusion about the Toolbox. See the extended description in the commits for some extra explanation.