### PR TITLE
Download shell scripts through HTTPS (requires vapor.sh server config fix!)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 dist: trusty
 osx_image: xcode8
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then eval "$(curl -sL swift.vapor.sh/ubuntu)"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then eval "$(curl -sL https://swift.vapor.sh/ubuntu)"; fi
 
   # run unit tests
   - swift build -Xswiftc -DNO_ANIMATION

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ brew install vapor/tap/toolbox
 ## Linux / Manual
 ```sh
 # install Vapor Toolbox
-curl -sL toolbox.qutheory.io | bash
+curl -sL https://toolbox.vapor.sh | bash
 ```

--- a/Sources/VaporToolbox/DockerInit.swift
+++ b/Sources/VaporToolbox/DockerInit.swift
@@ -29,7 +29,7 @@ public final class DockerInit: Command {
         initBar.start()
 
         do {
-            _ = try console.backgroundExecute(program: "curl", arguments: ["-L", "docker.vapor.sh", "-o", "Dockerfile"])
+            _ = try console.backgroundExecute(program: "curl", arguments: ["-L", "https://docker.vapor.sh", "-o", "Dockerfile"])
             initBar.finish()
         } catch ConsoleError.backgroundExecute(_, let message, _) {
             initBar.fail()

--- a/Sources/VaporToolbox/SelfUpdate.swift
+++ b/Sources/VaporToolbox/SelfUpdate.swift
@@ -19,7 +19,7 @@ public final class SelfUpdate: Command {
         let updateBar = console.loadingBar(title: "Updating")
         updateBar.start()
         do {
-            _ = try console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "curl -sL toolbox.vapor.sh | bash"])
+            _ = try console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "curl -sL https://toolbox.vapor.sh | bash"])
             updateBar.finish()
         } catch ConsoleError.backgroundExecute(_, let message, _) {
             updateBar.fail()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-curl -sL "check.vapor.sh" | bash || exit 1;
+curl -sL "https://check.vapor.sh" | bash || exit 1;
 
 DIR=".vapor-toolbox-temporary";
 


### PR DESCRIPTION
In several places (e.g. `vapor self update`), shell scripts are downloaded through HTTP:

    console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "curl -sL toolbox.vapor.sh | bash"])

A man-in-the-middle attack could intercept the connection and respond with a malicious shell script that would then be executed by bash.

Any such call should be changed to use HTTPS:

    console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "curl -sL https://toolbox.vapor.sh | bash"])

Unfortunately, only swift.vapor.sh seems to have a working SSL configuration at this time. The "check", "docker", and "toolbox" subdomains use the certificate for swift.vapor.sh and return a HTTP 500 error when connecting anyway. **This needs to be fixed before this pull request can be merged.**

See also https://github.com/vapor/documentation/pull/116.
