### PR TITLE
Added --web flag for generating project

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -13,8 +13,8 @@ public final class New: Command {
         "Creates a new Vapor application from a template.",
         "Use --template=repo/template for github templates",
         "Use --template=full-url-here.git for non github templates",
-        "Use --web to use the web template",
-        "If you want to create an API, you can use the --api flag or leave the flags blank",
+        "Use --web to create a new web app",
+        "Use --api (default) to create a new API",
     ]
 
     public let console: ConsoleProtocol
@@ -40,7 +40,7 @@ public final class New: Command {
                 "Sets the template to the web template: https://github.com/vapor/web-template",
             ]),
             Option(name: "api", help: [
-                "Sets the template to the api template: https://github.com/vapor/api-template",
+                "(Default) Sets the template to the api template: https://github.com/vapor/api-template",
             ])
         ]
     }

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -5,6 +5,7 @@ public final class New: Command {
     public let id = "new"
 
     public let defaultTemplate = "https://github.com/vapor/api-template"
+    public let webTemplate = "https://github.com/vapor/web-template"
 
     public let signature: [Argument]
 
@@ -12,6 +13,7 @@ public final class New: Command {
         "Creates a new Vapor application from a template.",
         "Use --template=repo/template for github templates",
         "Use --template=full-url-here.git for non github templates",
+        "Use --web to use the web template"
     ]
 
     public let console: ConsoleProtocol
@@ -32,6 +34,9 @@ public final class New: Command {
             ]),
             Option(name: "tag", help: [
                 "An optional tag to specify when cloning",
+            ]),
+            Option(name: "web", help: [
+                "Sets the template to the web template: https://github.com/vapor/web-template",
             ])
         ]
     }
@@ -132,7 +137,11 @@ public final class New: Command {
 
     private func loadTemplate(arguments: [String]) throws -> String {
         guard let template = arguments.options["template"]?.string else {
-            return defaultTemplate
+            if let _ = arguments.options["web"] {
+                return webTemplate
+            } else {
+                return defaultTemplate
+            }
         }
         return try expand(template: template)
     }

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -13,7 +13,8 @@ public final class New: Command {
         "Creates a new Vapor application from a template.",
         "Use --template=repo/template for github templates",
         "Use --template=full-url-here.git for non github templates",
-        "Use --web to use the web template"
+        "Use --web to use the web template",
+        "If you want to create an API, you can use the --api flag or leave the flags blank",
     ]
 
     public let console: ConsoleProtocol
@@ -37,6 +38,9 @@ public final class New: Command {
             ]),
             Option(name: "web", help: [
                 "Sets the template to the web template: https://github.com/vapor/web-template",
+            ]),
+            Option(name: "api", help: [
+                "Sets the template to the api template: https://github.com/vapor/api-template",
             ])
         ]
     }


### PR DESCRIPTION
This allows you to generate a project with the web template with a built-in flag instead of using the URL with the `template` flag.

    vapor new project --web