### PR TITLE
Update heroku init for the current status quo

### DIFF
--- a/Sources/VaporToolbox/HerokuInit.swift
+++ b/Sources/VaporToolbox/HerokuInit.swift
@@ -84,7 +84,7 @@ public final class HerokuInit: Command {
         if console.confirm("Would you like to provide a custom Heroku buildpack?") {
             buildpack = console.ask("Custom buildpack:")
         } else {
-            buildpack = "https://github.com/vapor/heroku-buildpack"
+            buildpack = "https://github.com/vapor-community/heroku-buildpack"
         }
 
 
@@ -105,7 +105,7 @@ public final class HerokuInit: Command {
         }
 
         console.info("Setting procfile...")
-        let procContents = "web: \(appName) --env=production --workdir=\"./\" --config:servers.default.port=\\$PORT"
+        let procContents = "web: \(appName) --env=production --port=\\$PORT"
         do {
             _ = try console.backgroundExecute(program: "/bin/sh", arguments: ["-c", "echo \"\(procContents)\" >> ./Procfile"])
         } catch ConsoleError.backgroundExecute(_, let message, _) {


### PR DESCRIPTION
This PR contains 2 tiny changes:
- workDir is no longer set in the Procfile (as it’s not needed since the cwd fix) and port is correctly set instead of the v1 config parameter;
- the buildpack is pulled in explicitly from the vapor-community organization (although it was still working thanks to GH’s redirection).