### PR TITLE
Add "n" to excluded arguments for the `xcode` command

### DIFF
--- a/Sources/VaporToolbox/Xcode.swift
+++ b/Sources/VaporToolbox/Xcode.swift
@@ -87,7 +87,7 @@ public final class Xcode: Command {
 
         // Setup passthrough
         let clean = arguments
-            .removeFlags(["clean", "run", "debug", "verbose", "fetch", "release", "y"])
+            .removeFlags(["clean", "run", "debug", "verbose", "fetch", "release", "y", "n"])
         buildFlags += clean
             .options
             .map { name, value in "--\(name)=\(value)" }


### PR DESCRIPTION
Permits the usage of the `-n` flag to explicitly refuse opening the Xcode project after generating it, to match the `-y` flag for explicit approval.

This could (and probably should?) be merged into `beta` branch too.

Classing as bug because the `-n` flag is already implemented but being incorrectly blocked.