### PR TITLE
Remove --enable-prefetching argument from SPM invocations.

### DIFF
--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -60,7 +60,7 @@ public final class Build: Command {
         let buildBar = console.loadingBar(title: "Building Project", animated: !isVerbose)
         buildBar.start()
 
-        let command =  ["build", "--enable-prefetching"] + buildFlags
+        let command =  ["build"] + buildFlags
         do {
             try console.execute(verbose: isVerbose, program: "swift", arguments: command)
             buildBar.finish()

--- a/Sources/VaporToolbox/Fetch.swift
+++ b/Sources/VaporToolbox/Fetch.swift
@@ -47,7 +47,7 @@ public final class Fetch: Command {
         try console.execute(
             verbose: isVerbose,
             program: "swift",
-            arguments: ["package", "--enable-prefetching", "fetch"] + pass
+            arguments: ["package", "fetch"] + pass
         )
         depBar.finish()
     }

--- a/Sources/VaporToolbox/Xcode.swift
+++ b/Sources/VaporToolbox/Xcode.swift
@@ -23,7 +23,7 @@ public final class Xcode: Command {
         xcodeBar.start()
 
         let buildFlags = try loadBuildFlags(arguments)
-        let argsArray = ["package"] + buildFlags + ["--enable-prefetching", "generate-xcodeproj"]
+        let argsArray = ["package"] + buildFlags + ["generate-xcodeproj"]
 
         do {
             _ = try console.execute(verbose: isVerbose, program: "swift", arguments: argsArray)

--- a/Tests/VaporToolboxTests/BuildTests.swift
+++ b/Tests/VaporToolboxTests/BuildTests.swift
@@ -7,9 +7,7 @@ extension TestConsole {
         let console = TestConsole()
 
         // swift commands
-        console.backgroundExecuteOutputBuffer["swift package --enable-prefetching fetch"] = ""
         console.backgroundExecuteOutputBuffer["swift package fetch"] = ""
-        console.backgroundExecuteOutputBuffer["swift build --enable-prefetching"] = ""
         console.backgroundExecuteOutputBuffer["swift build"] = ""
 
         console.backgroundExecuteOutputBuffer["swift package dump-package"] = try! JSON(["name": "Hello"]).serialize().makeString()
@@ -52,8 +50,8 @@ class BuildTests: XCTestCase {
         XCTAssertEqual(console.executeBuffer, [
             "ls -a .",
             "ls -a .",
-            "swift package --enable-prefetching fetch",
-            "swift build --enable-prefetching",
+            "swift package fetch",
+            "swift build",
             ])
     }
 
@@ -70,8 +68,8 @@ class BuildTests: XCTestCase {
             "rm -rf .build",
             "ls -a .",
             "ls -a .",
-            "swift package --enable-prefetching fetch",
-            "swift build --enable-prefetching",
+            "swift package fetch",
+            "swift build",
             ])
     }
 
@@ -89,8 +87,8 @@ class BuildTests: XCTestCase {
         XCTAssertEqual(console.executeBuffer, [
             "ls -a .",
             "ls -a .",
-            "swift package --enable-prefetching fetch",
-            "swift build --enable-prefetching",
+            "swift package fetch",
+            "swift build",
             "ls .build/debug",
             "find ./Sources -type f -name main.swift",
             "ls .build/debug/Hello",


### PR DESCRIPTION
 This option was removed in the SPM shipped with Swift 4.1 and is not critical in previous versions.