### PR TITLE
add `help` as default command

### DIFF
--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -7,6 +7,10 @@ import Cloud
 let version = "master"
 var arguments = CommandLine.arguments
 
+if arguments.count <= 0 {
+    arguments.insert("help", at: 1)
+}
+
 if arguments.contains("--version") {
     arguments.insert("version", at: 1)
 }


### PR DESCRIPTION
Instead of showing `Error: No command supplied.`
we can show help with commands