### PR TITLE
Adding git hash feature for Cloud

### DIFF
--- a/Sources/Cloud/Commands/CloudGitHash.swift
+++ b/Sources/Cloud/Commands/CloudGitHash.swift
@@ -1,0 +1,40 @@
+public final class CloudGitHash: Command {
+    public let id = "git-hash"
+
+    public let signature: [Argument] = []
+
+    public let help: [String] = [
+        "Get the Git has deployed live"
+    ]
+
+    public let console: ConsoleProtocol
+    public let cloudFactory: CloudAPIFactory
+
+    public init(_ console: ConsoleProtocol, _ cloudFactory: CloudAPIFactory) {
+        self.console = console
+        self.cloudFactory = cloudFactory
+    }
+
+    public func run(arguments: [String]) throws {
+        
+        let app = try console.application(for: arguments, using: cloudFactory)
+        let repoName = Identifier(app.repoName)
+        let env = try console.environment(
+            on: .identifier(repoName),
+            for: arguments,
+            using: cloudFactory
+        )
+
+        let cloud = try cloudFactory.makeAuthedClient(with: console)
+        guard let token = try cloud.accessTokenFactory?.makeAccessToken() else {
+            throw "No access token"
+        }
+
+        try CloudRedis.gitHash(
+            console: console,
+            repo: app.repoName,
+            envName: env.name,
+            with: token
+        )
+    }
+}

--- a/Sources/Cloud/Commands/Group.swift
+++ b/Sources/Cloud/Commands/Group.swift
@@ -68,6 +68,7 @@ public func group(_ console: ConsoleProtocol) throws -> Group {
             create,
             // Run remote commands
             CloudRun(console, cloudFactory),
+            CloudGitHash(console, cloudFactory),
             config,
             database,
             // Temporarily disabling not ready commands


### PR DESCRIPTION
Adding feature to get git hash from Vapor Cloud replicas.

e.g.:

```
vapor cloud git-hash
```