### PR TITLE
Display commit hash on the initial commit message

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -55,6 +55,7 @@ public final class New: Command {
         let name = try value("name", from: arguments)
         let gitDir = "--git-dir=./\(name)/.git"
         let workTree = "--work-tree=./\(name)"
+        var commitHash: String?
 
         let isVerbose = arguments.isVerbose
         let cloneBar = console.loadingBar(title: "Cloning Template", animated: !isVerbose)
@@ -70,6 +71,11 @@ public final class New: Command {
                     arguments: [gitDir, workTree, "checkout", checkout]
                 )
             }
+            commitHash = try console.backgroundExecute(
+                program: "git",
+                arguments: [gitDir, "rev-parse", "HEAD"]
+            )
+            commitHash = commitHash?.trim()
 
             _ = try console.backgroundExecute(program: "rm", arguments: ["-rf", "\(name)/.git"])
 
@@ -101,7 +107,11 @@ public final class New: Command {
         do {
             _ = try console.execute(verbose: isVerbose, program: "git", arguments: [gitDir, "init"])
             _ = try console.execute(verbose: isVerbose, program: "git", arguments: [gitDir, workTree, "add", "."])
-            let msg = "created \(name) from template \(template)"
+            var msg = "created \(name) from template \(template)"
+            commitHash = nil
+            if let commitHash = commitHash {
+                msg.append("/tree/\(commitHash)")
+            }
             _ = try console.execute(
                 verbose: isVerbose,
                 program: "git",

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -101,10 +101,11 @@ public final class New: Command {
         do {
             _ = try console.execute(verbose: isVerbose, program: "git", arguments: [gitDir, "init"])
             _ = try console.execute(verbose: isVerbose, program: "git", arguments: [gitDir, workTree, "add", "."])
+            let msg = "created \(name) from template \(template)"
             _ = try console.execute(
                 verbose: isVerbose,
                 program: "git",
-                arguments: [gitDir, workTree, "commit", "-m", "'created \(name) from template \(template)'"]
+                arguments: [gitDir, workTree, "commit", "-m", "'\(msg)'"]
             )
             gitBar.finish()
         } catch ConsoleError.backgroundExecute(_, let error, let output) {


### PR DESCRIPTION
Vapor templates are growing up fast, so I'd like to know the exact template revision used for my app.

```
$ git log -1
commit ab225c1a0e1d9729818c401de28457e6ed31982a (HEAD -> master)
Author: hkdnet <xxx@example.com>
Date:   Wed May 9 06:21:16 2018 +0900

    'created foo from template https://github.com/vapor/api-template/tree/3df9b5518b510f5959c75ad04c1b51996a75e367'
```