### PR TITLE
Fix bug where arguments are dropped incorrectly

### DIFF
--- a/Sources/Cloud/Commands/Configs/ConfigModify.swift
+++ b/Sources/Cloud/Commands/Configs/ConfigModify.swift
@@ -48,7 +48,7 @@ public final class ConfigModify: Command {
         
         let configs: [Configuration] = try arguments.flatMap { arg in
                 return arg.hasPrefix("--") ? nil : arg
-        }.dropFirst(2).array.map { config in
+        }.array.map { config in
             let parts = config.characters.split(separator: "=", maxSplits: 1)
             guard parts.count == 2 else {
                 throw "Invalid config '\(config)'. Format must be KEY=VALUE."


### PR DESCRIPTION
This bug meant that it was necessary to add two random arguments when modifying key-value pairs.

Instead of this being correct: vapor cloud config modify FOO=BAR HELLO=WORLD
This was necessary: vapor cloud config modify random arguments FOO=BAR HELLO=WORLD