### PR TITLE
Added —location to curl request to follow redirects for private repos

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -187,6 +187,7 @@ public final class New: Command {
                     "-o",
                     "/dev/null",
                     "--silent",
+                    "--location",
                     "--head",
                     "--write-out",
                     "'%{http_code}\\n'",


### PR DESCRIPTION
When trying to start a new project using a custom template that existed on Gitlab:
```
vapor new projectName --template=https://gitlab.com/xxxx/xxxx.git
```
returns:
```
fatal: repository 'https://github.com/https://gitlab.com/xxxx/xxxx.git' not found
```

after looking into the code and seeing that it runs a curl command, running it locally showed that it returns a 302.

After adding a local `~/.curlrc` to include `location` it then worked. 

I believe that the curl command should include the `--location` to follow redirects automatically for private repos, and that a local `.curlrc` file should not be required.