### PR TITLE
Remove harmful checkGitUpstream call from Update

### DIFF
--- a/Sources/VaporToolbox/Update.swift
+++ b/Sources/VaporToolbox/Update.swift
@@ -19,8 +19,6 @@ public final class Update: Command {
     }
 
     public func run(arguments: [String]) throws {
-        try checkGitUpstream()
-
         let isVerbose = arguments.isVerbose
         let bar = console.loadingBar(title: "Updating", animated: !isVerbose)
         bar.start()
@@ -34,37 +32,5 @@ public final class Update: Command {
             let xcode = Xcode(console: console)
             try xcode.run(arguments: arguments)
         #endif
-    }
-
-    func checkGitUpstream() throws {
-        guard gitInfo.isGitProject() else { return }
-        let currentBranch = try gitInfo.currentBranch()
-        
-        if let upstream = try? gitInfo.upstreamBranch() {
-            try gitInfo.verify(
-                local: currentBranch,
-                remote: upstream.remote,
-                upstream: upstream.branch
-            )
-        } else {
-            let remotes = try gitInfo.remoteNames()
-            let remote: String
-            if remotes.isEmpty {
-                return
-            } else if remotes.count == 1 {
-                remote = remotes[0]
-            } else if remotes.contains("origin") {
-                remote = "origin"
-            } else {
-                remote = try console.giveChoice(
-                    title: "Which remote are you tracking for '\(currentBranch)'?",
-                    in: remotes
-                )
-            }
-            try gitInfo.verify(
-                local: currentBranch,
-                remote: remote
-            )
-        }
     }
 }


### PR DESCRIPTION
So I was getting a bit bored of explaining how to use `swift package update` instead of `vapor update` when things go south. This PR removes the offending function from the code, thus fixes #234 and fixes #215.