### PR TITLE
Changing Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
     <a href="http://beta.docs.vapor.codes/getting-started/toolbox/">
         <img src="http://img.shields.io/badge/read_the-docs-92A8D1.svg" alt="Documentation">
     </a>
-    <a href="http://vapor.team">
-        <img src="http://vapor.team/badge.svg" alt="Slack Team">
-    </a>
     <a href="LICENSE">
         <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
     </a>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
     <a href="http://beta.docs.vapor.codes/getting-started/toolbox/">
         <img src="http://img.shields.io/badge/read_the-docs-92A8D1.svg" alt="Documentation">
     </a>
+    <a href="https://discord.gg/vapor">
+        <img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat">
+    </a>
     <a href="LICENSE">
         <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
     </a>

--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -124,7 +124,7 @@ public final class Build: Command {
         console.print()
 
         console.info("Help:")
-        console.print("Join our Slack where hundreds of contributors")
+        console.print("Join our team chat where hundreds of contributors")
         console.print("are waiting to help: http://vapor.team")
         console.print()
 

--- a/Sources/VaporToolbox/Test.swift
+++ b/Sources/VaporToolbox/Test.swift
@@ -34,7 +34,7 @@ public final class Test: Command {
             console.info(message)
             console.print()
             console.info("Help:")
-            console.print("Join our Slack where hundreds of contributors")
+            console.print("Join our team chat where hundreds of contributors")
             console.print("are waiting to help: http://vapor.team")
             console.print()
 


### PR DESCRIPTION
If we tag another release, let's make this small change to remove "Slack" from two messages.

Nothing urgent.