### PR TITLE
Update error output for CommandError as enum

### DIFF
--- a/Sources/Executable/main.swift
+++ b/Sources/Executable/main.swift
@@ -6,8 +6,7 @@ do {
 } catch let error as CommandError {
     let term = Terminal()
     term.error("error:")
-    term.output("reason: " + error.reason.consoleText())
-    term.output("identifier: " + error.identifier.consoleText())
+    term.output(error.description.consoleText())
 } catch {
     let term = Terminal()
     term.error("error:")


### PR DESCRIPTION
Since CommandError is now an enum, we need to change all consumers of console-kit.

Also, shouldn't we pin the dependencies for the homebrew build? It seems it is using the latest of everything at the moment, and that might break easily.