### PR TITLE
Fixed issue where Package.swift was misspelled in the xcode command

### DIFF
--- a/Sources/VaporToolbox/XcodeCommand.swift
+++ b/Sources/VaporToolbox/XcodeCommand.swift
@@ -10,6 +10,6 @@ struct XcodeCommand: Command {
     
     /// See `Command`.
     func run(using ctx: CommandContext, signature: Signature) throws {
-        try Shell.bash("open Package.siwft")
+        try Shell.bash("open Package.swift")
     }
 }


### PR DESCRIPTION
Fixes issue #294