### PR TITLE
Add shell escaping, use FileManager where possible, add new options to vapor new, cleanup of vapor clean

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,11 +11,11 @@
         }
       },
       {
-        "package": "Mustache",
+        "package": "mustache",
         "repositoryURL": "https://github.com/tanner0101/mustache.git",
         "state": {
           "branch": null,
-          "revision": "2169b3a2ba3add4957faaa1bdaa0b7b1e0013b08",
+          "revision": "94104a84964fabb9c4b2dfb792ea6e655e79a0bf",
           "version": "0.1.0"
         }
       },
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "a27a07719ca785bcaca019a5b9fe1814b981b4a2",
+          "version": "2.15.0"
         }
       },
       {

--- a/Sources/VaporToolbox/Clean.swift
+++ b/Sources/VaporToolbox/Clean.swift
@@ -6,8 +6,6 @@ struct Clean: Command {
     struct Signature: CommandSignature {
         @Flag(name: "update", short: "u", help: "Delete Package.resolved file if it exists.")
         var update: Bool
-        @Flag(name: "keep-checkouts", short: "k", help: "Keep git checkouts of dependencies.")
-        var keepCheckouts: Bool
         @Flag(name: "global", short: "g", help: "Clean Xcode's global DerivedData cache.")
         var global: Bool
         @Flag(name: "swiftpm", short: "s", help: "Delete .swiftpm folder.")
@@ -93,13 +91,7 @@ class Cleaner {
 
     private func cleanBuildFolder() throws -> CleanResult {
         guard files.contains(".build") else { return .notNecessary }
-        var list = try Process.shell.allFiles(in: ".build").split(separator: "\n")
-        if sig.keepCheckouts {
-            list.removeAll(where: ["checkouts", ".", ".."].contains)
-            try list.map { ".build/" + $0 } .forEach(Process.shell.delete)
-        } else {
-            try Process.shell.delete(".build")
-        }
+        try FileManager.default.removeItem(atPath: self.cwd.appendingPathComponents(".build"))
         return .success
     }
 

--- a/Sources/VaporToolbox/New/New.swift
+++ b/Sources/VaporToolbox/New/New.swift
@@ -6,62 +6,73 @@ struct New: Command {
     struct Signature: CommandSignature {
         @Argument(name: "name", help: "Name of project and folder.")
         var name: String
+        
+        @Option(name: "template", short: "T", help: "The URL of a Git repository to use as a template.")
+        var templateURL: String?
+        
+        @Option(name: "outputDirectory", short: "o", help: "The directory to place the new project in.")
+        var outputDirectory: String?
     }
 
     let help = "Generates a new app."
 
     func run(using ctx: CommandContext, signature: Signature) throws {
         let name = signature.name
-        let gitUrl = "https://github.com/vapor/template"
+        let gitUrl = signature.templateURL ?? "https://github.com/vapor/template"
+        let cwd = FileManager.default.currentDirectoryPath
+        let workTree = signature.outputDirectory?.asDirectoryURL.path ?? cwd.appendingPathComponents(name)
+        let templateTree = workTree.deletingLastPathComponents().appendingPathComponents(".vapor-template")
 
-        // Cloning
         ctx.console.info("Cloning template...")
-        let _ = try Process.git.clone(repo: gitUrl, toFolder: "./" + name)
+        try? FileManager.default.removeItem(atPath: templateTree)
+        _ = try Process.git.clone(repo: gitUrl, toFolder: templateTree)
 
-        // used to work on a git repository
-        // outside of current path
-        let gitDir = "./\(name)/.git"
-        let workTree = "./\(name)"
-
-        if FileManager.default.fileExists(atPath: workTree.trailingSlash + "manifest.yml") {
-            try? Process.shell.delete(".vapor-template")
-            try Process.shell.move(name, to: ".vapor-template")
-            try Process.shell.makeDirectory(name)
-            let yaml = try Process.shell.readFile(path: ".vapor-template/manifest.yml")
+        if FileManager.default.fileExists(atPath: templateTree.appendingPathComponents("manifest.yml")) {
+            try FileManager.default.createDirectory(atPath: workTree, withIntermediateDirectories: false, attributes: nil)
+            let yaml = try String(contentsOf: templateTree.appendingPathComponents("manifest.yml").asFileURL, encoding: .utf8)
             let manifest = try YAMLDecoder().decode(TemplateManifest.self, from: yaml)
-            let cwd = try Process.shell.cwd()
             let scaffolder = TemplateScaffolder(console: ctx.console, manifest: manifest)
-            try scaffolder.scaffold(
-                name: name,
-                from: cwd.trailingSlash + ".vapor-template",
-                to: cwd.trailingSlash + name
-            )
-            try Process.shell.delete(".vapor-template")
+            try scaffolder.scaffold(name: name, from: templateTree.trailingSlash, to: workTree.trailingSlash)
+            try FileManager.default.removeItem(atPath: templateTree)
+        } else {
+            try FileManager.default.moveItem(atPath: templateTree, toPath: workTree)
         }
         
         // clear existing git history
+        let gitDir = workTree.appendingPathComponents(".git")
+
         ctx.console.info("Creating git repository")
-        try Process.shell.delete("./\(name)/.git")
-        let _ = try Process.git.create(gitDir: gitDir)
+        if FileManager.default.fileExists(atPath: gitDir) {
+            try FileManager.default.removeItem(atPath: gitDir)
+        }
+        _ = try Process.git.create(gitDir: gitDir)
 
         // initialize
         ctx.console.info("Adding first commit")
-        try Process.git.commit(
-            gitDir: gitDir,
-            workTree: workTree,
-            msg: "first commit"
-        )
+        try Process.git.commit(gitDir: gitDir, workTree: workTree, msg: "first commit")
         
         // print the Droplet
-
         var copy = ctx
         try PrintDroplet().run(using: &copy)
+        
+        // figure out the shortest relative path to the new project
+        var cdInstruction = workTree.lastPathComponent
+        switch workTree.deletingLastPathComponents(1).commonPrefix(with: cwd).trailingSlash {
+            case cwd.trailingSlash: // is in current directory
+                break
+            case cwd.deletingLastPathComponents(1).trailingSlash: // reachable from one level up
+                cdInstruction = "..".appendingPathComponents(workTree.pathComponents.suffix(1))
+            case cwd.deletingLastPathComponents(2).trailingSlash: // reachable from two levels up
+                cdInstruction = "../..".appendingPathComponents(workTree.pathComponents.suffix(2))
+            default: // too distant to be worth expressing as a relative path
+                cdInstruction = workTree
+        }
         
         // print info
         ctx.console.center([
             "Project " + name.consoleText(.info) + " has been created!",
             "",
-            "Use " + "cd \(name)".consoleText(.info) + " to enter the project directory",
+            "Use " + "cd \(Process.shell.escapeshellarg(cdInstruction))".consoleText(.info) + " to enter the project directory",
             "Use " + "vapor xcode".consoleText(.info) + " to open the project in Xcode",
         ]).forEach { ctx.console.output($0) }
     }

--- a/Sources/VaporToolbox/Shell.swift
+++ b/Sources/VaporToolbox/Shell.swift
@@ -73,7 +73,7 @@ struct Shell {
     func run(_ program: String, _ arguments: [String]) throws -> String {
         let process = Process(
             program: self.program,
-            arguments: ["-c", program + " " + arguments.joined(separator: " ")]
+            arguments: ["-c", "'\(program)' \(arguments.map { "'\($0)'" }.joined(separator: " "))"]
         )
         try process.runUntilExit()
         return process.stdout.read()

--- a/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
@@ -12,8 +12,8 @@ struct SupervisorInit: Command {
 
     func run(using context: CommandContext, signature: Signature) throws {
         let package = try Process.swift.package.dump()
-        let cwd = try Process.shell.cwd()
-        let user = try Process.shell.whoami()
+        let cwd = FileManager.default.currentDirectoryPath
+        let user = NSUserName()
         let config = SupervisorConfiguration(
             program: package.name,
             attributes: [

--- a/Sources/VaporToolbox/Utilities.swift
+++ b/Sources/VaporToolbox/Utilities.swift
@@ -1,4 +1,5 @@
 import ConsoleKit
+import Foundation
 
 extension String {
     public var trailingSlash: String {
@@ -7,6 +8,51 @@ extension String {
     public func finished(with tail: String) -> String {
         guard hasSuffix(tail) else { return self + tail }
         return self
+    }
+    
+    // Please note regarding the replacements for `NSPathUtilities` methods found below: The equivalent Foundation
+    // methods are hidden from Swift for _GOOD REASON_. Please just use real URLs whenever possible.
+
+    /// Convenience wrapper for `URL(fileURLWithPath:isDirectory:)`. This
+    /// accessor should not be used if the path refers to a directory, but is
+    /// more correct than `.asDirectoryURL` if the directory-ness is unknown.
+    public var asFileURL: URL {
+        return URL(fileURLWithPath: self, isDirectory: false)
+    }
+    
+    /// Convenience wrapper for `URL(fileURLWithPath:isDirectory:)`. This
+    /// accessor must not be used if the path refers to a file. If you don't
+    /// know whether or not it refers to a directory, use `.asFileURL` instead.
+    public var asDirectoryURL: URL {
+        return URL(fileURLWithPath: self, isDirectory: true)
+    }
+    
+    /// Convenience wrapper for `URL.pathComponents`
+    public var pathComponents: [String] {
+        return self.asFileURL.pathComponents
+    }
+    
+    /// Convenience wrapper for `URL.lastPathComponent`
+    public var lastPathComponent: String {
+        return self.asFileURL.lastPathComponent
+    }
+    
+    /// Convenience wrapper for repeated invocations of
+    /// `URL.appendingPathComponent()` and `URL(fileURLWithPath:isDirectory:)`.
+    public func appendingPathComponents(_ components: String...) -> String {
+        return self.appendingPathComponents(components)
+    }
+    
+    /// Convenience wrapper for repeated invocations of
+    /// `URL.appendingPathComponent()` and `URL(fileURLWithPath:isDirectory:)`.
+    public func appendingPathComponents(_ components: [String]) -> String {
+        return components.reduce(self.asDirectoryURL) { $0.appendingPathComponent($1) }.relativePath
+    }
+    
+    /// Convenience wrapper for repeated invocations of
+    /// `URL.deletingLastPathComponent()`.
+    public func deletingLastPathComponents(_ count: Int = 1) -> String {
+        return (0..<count).reduce(self.asFileURL) { url, _ in url.deletingLastPathComponent() }.relativePath
     }
 }
 

--- a/Sources/VaporToolbox/Xcode/Xcode.swift
+++ b/Sources/VaporToolbox/Xcode/Xcode.swift
@@ -1,5 +1,8 @@
 import ConsoleKit
 import Foundation
+#if os(macOS)
+import AppKit
+#endif
 
 // Generates an Xcode project
 struct Xcode: Command {
@@ -11,7 +14,11 @@ struct Xcode: Command {
     func run(using ctx: CommandContext, signature: Signature) throws {
         ctx.console.info("Opening project in Xcode.")
         do {
+            #if os(macOS)
+            NSWorkspace.shared.open(FileManager.default.currentDirectoryPath.appendingPathComponents("Package.swift").asFileURL)
+            #else
             try Process.shell.run("open", "Package.swift")
+            #endif
         } catch {
             ctx.console.output("note: ".consoleText(.warning) + "Call this command from the project's root folder.")
             throw error


### PR DESCRIPTION
- All executed shell commands now properly escape their arguments.
- Use of shell execution has been replaced with use of `FileManager` in most places.
- `vapor new` now has a `-T/--template` option which allows specifying a template repository to clone.
- `vapor new` now has a `-o/--outputDirectory` option which allows specifying where and with what name the new project directory is created. The directory name does _NOT_ have to match the project name, though it is recommended.
- `vapor clean` no longer has a `-k/--keep-checkouts` option, as it did not usefully perform as advertised.
- Update to NIO 2.15
- Project paths and names may now contain spaces and special characters, though names in particular should be kept as simple as possible.