### PR TITLE
Fix issues with Swift 5.2 on Ubuntu

### DIFF
--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -7,7 +7,7 @@ struct Build: AnyCommand {
 
     func run(using context: inout CommandContext) throws {
         context.console.output("Building project...")
-        try exec(Process.shell.which("swift"), ["build"] + context.input.arguments)
+        try exec(Process.shell.which("swift"), ["build", "--enable-test-discovery"] + context.input.arguments)
         context.console.info("Project built.")
     }
 }

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -6,7 +6,7 @@ struct Run: AnyCommand {
     let help = "Runs an app from the console."
 
     func run(using context: inout CommandContext) throws {
-        try exec("/usr/bin/swift", ["run", "Run"] + context.input.arguments)
+        try exec("/usr/bin/swift", ["run", "--enable-test-discovery", "Run"] + context.input.arguments)
     }
 
     func outputHelp(using context: inout CommandContext) {

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -6,7 +6,7 @@ struct Run: AnyCommand {
     let help = "Runs an app from the console."
 
     func run(using context: inout CommandContext) throws {
-        try exec("/usr/bin/swift", ["run", "--enable-test-discovery", "Run"] + context.input.arguments)
+        try exec(Process.shell.which("swift"), ["run", "--enable-test-discovery", "Run"] + context.input.arguments)
     }
 
     func outputHelp(using context: inout CommandContext) {


### PR DESCRIPTION
This mainly includes:
> Add `--enable-test-discovery` flag as default

While also fixed:
> Fix hard-coded Swift path