### PR TITLE
update Dockerfile to 5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM swift:5.1 as build
+FROM swift:5.2 as build
 WORKDIR /toolbox
 COPY . .
 RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
 RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
 
-FROM swift:5.1-slim
+FROM swift:5.2-slim
 WORKDIR /toolbox
 COPY --from=build /build/bin/vapor /usr/bin
 COPY --from=build /build/lib/* /usr/lib/


### PR DESCRIPTION
`docker build` doesn't work anymore due to swift 5.2 being required, so i updated the Dockerfile to 5.2.