### PR TITLE
Fix for Ubuntu 20.04 raspberry pi 4

### DIFF
--- a/Sources/VaporToolbox/exec.swift
+++ b/Sources/VaporToolbox/exec.swift
@@ -8,7 +8,22 @@ func exec(_ program: String, _ arguments: String...) throws {
 
 func exec(_ program: String, _ arguments: [String]) throws {
     var pid = pid_t()
+
+    /*
+     
+     There is an error when running command 'vapor-beta run' on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3
+     
+     Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift, line 13
+
+    */
+    
+    // Usinng '#if os(Linux)' and 'posix_spawn_file_actions_t()' to fix issue described above
+    // Need to check if this doesn't break things on other distributions and devices
+    #if os(Linux)
+    var fileActions = posix_spawn_file_actions_t()
+    #else
     var fileActions: posix_spawn_file_actions_t!
+    #endif
 
     posix_spawn_file_actions_init(&fileActions)
     defer {
@@ -19,7 +34,18 @@ func exec(_ program: String, _ arguments: [String]) throws {
     posix_spawn_file_actions_adddup2(&fileActions, FileHandle.standardOutput.fileDescriptor, 1)
     posix_spawn_file_actions_adddup2(&fileActions, FileHandle.standardError.fileDescriptor, 2)
 
-    let argv = ([program] + arguments).map {
+    /*
+    
+     There is an error when building toolbox-18.0.0-beta.28 on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3
+     
+     /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift:36:42: error: value of optional type 'UnsafeMutablePointer<Int8>?' must be unwrapped to a value of type 'UnsafeMutablePointer<Int8>'
+     let spawned = posix_spawnp(&pid, argv[0], &fileActions, nil, argv + [nil], envp + [nil])
+     
+    */
+
+    // Using compactMap to fix issue described above
+    // Need to check if this doesn't break things on other distributions and devices
+    let argv = ([program] + arguments).compactMap {
         $0.withCString(strdup)
     }
     defer {

--- a/Sources/VaporToolbox/exec.swift
+++ b/Sources/VaporToolbox/exec.swift
@@ -9,16 +9,6 @@ func exec(_ program: String, _ arguments: String...) throws {
 func exec(_ program: String, _ arguments: [String]) throws {
     var pid = pid_t()
 
-    /*
-     
-     There is an error when running command 'vapor-beta run' on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3
-     
-     Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift, line 13
-
-    */
-    
-    // Usinng '#if os(Linux)' and 'posix_spawn_file_actions_t()' to fix issue described above
-    // Need to check if this doesn't break things on other distributions and devices
     #if os(Linux)
     var fileActions = posix_spawn_file_actions_t()
     #else
@@ -34,17 +24,6 @@ func exec(_ program: String, _ arguments: [String]) throws {
     posix_spawn_file_actions_adddup2(&fileActions, FileHandle.standardOutput.fileDescriptor, 1)
     posix_spawn_file_actions_adddup2(&fileActions, FileHandle.standardError.fileDescriptor, 2)
 
-    /*
-    
-     There is an error when building toolbox-18.0.0-beta.28 on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3
-     
-     /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift:36:42: error: value of optional type 'UnsafeMutablePointer<Int8>?' must be unwrapped to a value of type 'UnsafeMutablePointer<Int8>'
-     let spawned = posix_spawnp(&pid, argv[0], &fileActions, nil, argv + [nil], envp + [nil])
-     
-    */
-
-    // Using compactMap to fix issue described above
-    // Need to check if this doesn't break things on other distributions and devices
     let argv = ([program] + arguments).compactMap {
         $0.withCString(strdup)
     }


### PR DESCRIPTION
There is an error when building toolbox-18.0.0-beta.28 on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3
     
 /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift:36:42: error: value of optional type 'UnsafeMutablePointer<Int8>?' must be unwrapped to a value of type 'UnsafeMutablePointer<Int8>'
let spawned = posix_spawnp(&pid, argv[0], &fileActions, nil, argv + [nil], envp + [nil])

Using compactMap to fix issue described above

----------------------------------------------------

There is an error when running command 'vapor-beta run' on raspberry pi 4 Ubuntu 20.04 Swift 5.2.3 

Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file /home/ubuntu/toolbox-18.0.0-beta.28/Sources/VaporToolbox/exec.swift, line 13

Using '#if os(Linux)' and 'posix_spawn_file_actions_t()' to fix issue described above
Need to check if this doesn't break things on other distributions and devices
    
