### PR TITLE
Add lowercased "name_lower" key to Moustache context

### DIFF
--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -17,6 +17,7 @@ struct TemplateScaffolder {
         assert(destination.hasPrefix("/"))
         var context: [String: MustacheData] = [:]
         context["name"] = .string(name)
+        context["name_lower"] = .string(name.lowercased())
         self.console.output(key: "name", value: name)
         for variable in self.manifest.variables {
             try self.ask(variable: variable, to: &context)


### PR DESCRIPTION
This key will be used in the docker-compose file of the template, in order to fix: https://github.com/vapor/template/issues/29