### PR TITLE
Add --version flag

### DIFF
--- a/Sources/VaporToolbox/boot.swift
+++ b/Sources/VaporToolbox/boot.swift
@@ -49,8 +49,28 @@ final class Main: CommandGroup {
                 context.console.output("\("note:", style: .warning) could not determine toolbox version.")
                 context.console.output(key: "toolbox", value: "not found")
             }
+        } else if let command = try self.commmand(using: &context) {
+            try command.run(using: &context)
+        } else if let `default` = self.defaultCommand {
+            return try `default`.run(using: &context)
         } else {
             try self.outputHelp(using: &context)
+            throw CommandError.missingCommand
+        }
+    }
+
+    private func commmand(using context: inout CommandContext) throws -> AnyCommand? {
+        if let name = context.input.arguments.first {
+            context.input.arguments.removeFirst()
+            guard let command = self.commands[name] else {
+                throw CommandError.unknownCommand(name, available: Array(self.commands.keys))
+            }
+            // executable should include all subcommands
+            // to get to the desired command
+            context.input.executablePath.append(name)
+            return command
+        } else {
+            return nil
         }
     }
 }

--- a/Sources/VaporToolbox/boot.swift
+++ b/Sources/VaporToolbox/boot.swift
@@ -39,7 +39,8 @@ final class Main: CommandGroup {
                 let brewString = try Process.shell.run("brew", "info", "vapor")
                 let versionFinder = try NSRegularExpression(pattern: #"(\d+\.)(\d+\.)(\d)"#)
                 let versionString = String(brewString.split(separator: "\n")[0])
-                if let version = versionFinder.firstMatch(in: versionString, options: [], range: .init(location: 0, length: versionString.utf16.count)) {
+                if let match = versionFinder.firstMatch(in: versionString, options: [], range: .init(location: 0, length: versionString.utf16.count)) {
+                    let version = versionString[Range(match.range, in: versionString)!]
                     context.console.output(key: "toolbox", value: "\(version)")
                 } else {
                     context.console.output(key: "toolbox", value: versionString)

--- a/Sources/VaporToolbox/boot.swift
+++ b/Sources/VaporToolbox/boot.swift
@@ -37,7 +37,13 @@ final class Main: CommandGroup {
             }
             do {
                 let brewString = try Process.shell.run("brew", "info", "vapor")
-                context.console.output(key: "toolbox", value: "\(brewString.split(separator: "\n")[0])")
+                let versionFinder = try NSRegularExpression(pattern: #"^(\d+\.)?(\d+\.)?(\*|\d+)$"#)
+                let versionString = String(brewString.split(separator: "\n")[0])
+                if let version = versionFinder.firstMatch(in: versionString, options: [], range: .init(location: 0, length: versionString.utf16.count)) {
+                    context.console.output(key: "toolbox", value: "\(version)")
+                } else {
+                    context.console.output(key: "toolbox", value: versionString)
+                }
             } catch {
                 context.console.output("\("note:", style: .warning) could not determine toolbox version.")
                 context.console.output(key: "toolbox", value: "not found")

--- a/Sources/VaporToolbox/boot.swift
+++ b/Sources/VaporToolbox/boot.swift
@@ -37,7 +37,7 @@ final class Main: CommandGroup {
             }
             do {
                 let brewString = try Process.shell.run("brew", "info", "vapor")
-                let versionFinder = try NSRegularExpression(pattern: #"^(\d+\.)?(\d+\.)?(\*|\d+)$"#)
+                let versionFinder = try NSRegularExpression(pattern: #"(\d+\.)(\d+\.)(\d)"#)
                 let versionString = String(brewString.split(separator: "\n")[0])
                 if let version = versionFinder.firstMatch(in: versionString, options: [], range: .init(location: 0, length: versionString.utf16.count)) {
                     context.console.output(key: "toolbox", value: "\(version)")


### PR DESCRIPTION
Adds a global `--version` flag for printing framework and toolbox version. 

```sh
$ vapor --version
framework: 4.15.2
toolbox: 18.1.0
```