### PR TITLE
Forward confirm override

### DIFF
--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -6,7 +6,11 @@ struct Run: AnyCommand {
     let help = "Runs an app from the console."
 
     func run(using context: inout CommandContext) throws {
-        try exec(Process.shell.which("swift"), ["run", "--enable-test-discovery", "Run"] + context.input.arguments)
+        var extraArguments: [String] = []
+        if let confirmOverride = context.console.confirmOverride {
+            extraArguments.append(confirmOverride ? "--yes" : "--no")
+        }
+        try exec(Process.shell.which("swift"), ["run", "--enable-test-discovery", "Run"] + context.input.arguments + extraArguments)
     }
 
     func outputHelp(using context: inout CommandContext) {


### PR DESCRIPTION
`vapor run` now correctly forwards the confirm override flag (`--yes` or `--no`) to the app (#333, fixes #332). 