### PR TITLE
Add Makefile + optional static version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+VERSION := $(shell ./scripts/current-version.sh)
 
 build:
 	# Set version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+VERSION := $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+
+build:
+	# Set version
+	sed -i '' 's/nil/"${VERSION}"/g' Sources/VaporToolbox/Version.swift
+	# Build
+	swift build \
+		--disable-sandbox \
+		--configuration release \
+		-Xswiftc -cross-module-optimization \
+		--enable-test-discovery
+	# Reset version
+	sed -i '' 's/"${VERSION}"/nil/g' Sources/VaporToolbox/Version.swift
+install: build
+	mv .build/release/vapor /usr/local/bin/vapor-make
+uninstall:
+	rm /usr/local/bin/vapor-make
+clean:
+	rm -rf .build

--- a/Sources/VaporToolbox/Version.swift
+++ b/Sources/VaporToolbox/Version.swift
@@ -1,0 +1,3 @@
+// This file is edited by Makefile
+// Do not change manually.
+let staticVersion: String? = nil

--- a/scripts/current-version.sh
+++ b/scripts/current-version.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match) ($(git rev-parse --short HEAD))"

--- a/scripts/current-version.sh
+++ b/scripts/current-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match) ($(git rev-parse --short HEAD))"

--- a/scripts/current-version.swift
+++ b/scripts/current-version.swift
@@ -1,0 +1,40 @@
+#!/usr/bin/env swift
+import Foundation
+
+try print(currentVersion())
+
+func currentVersion() throws -> String {
+    do {
+        let tag = try shell("git", "describe", "--tags", "--exact-match")
+        return tag
+    } catch {
+        let branch = try shell("git", "symbolic-ref", "-q", "--short", "HEAD")
+        let commit = try shell("git", "rev-parse", "--short", "HEAD")
+        return "\(branch) (\(commit))"
+    }
+}
+
+func shell(_ args: String...) throws -> String {
+    let task = Process()
+    task.launchPath = "/usr/bin/env"
+    task.arguments = args
+    // grab stdout
+    let output = Pipe()
+    task.standardOutput = output
+    // ignore stderr
+    let error = Pipe()
+    task.standardError = error
+    task.launch()
+    task.waitUntilExit()
+
+    guard task.terminationStatus == 0 else {
+        throw ShellError(terminationStatus: task.terminationStatus)
+    }
+
+    return String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+struct ShellError: Error {
+    var terminationStatus: Int32
+}


### PR DESCRIPTION
Adds a Makefile with `build`, `install`, and `uninstall` commands (#339, fixes #338)

Using `make build` will attempt to infer the current toolbox version number and compile it into the executable for lookup via `--version`. 

Sample output:

```
$ vapor --version
framework: 4.27.1
toolbox: tn-version-number (90e3d12)
```