### PR TITLE
Makefile permissions issue fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ build:
 	./build
 	rm ./build
 install: build
-	mv .build/release/vapor ${DEST}
+	sudo mv .build/release/vapor ${DEST}
+	sudo chmod 755 ${DEST}
 uninstall:
-	rm ${DEST}
+	sudo rm ${DEST}
 clean:
 	rm -rf .build


### PR DESCRIPTION
Adds `sudo` to the lines `mv .build/release/vapor ${DEST}` and `rm ${DEST}`, since root level permissions are required to make changes to `$DEST` (/usr/local/bin). (Note that simply running `sudo make install` without this change will result in errors.) Also added a line to change the permissions of the build moved into `/usr/local/bin` to match with standard conventions.
Possibly fixes issue #347, but not enough detail is noted in said issue to know if it's the same problem.