### PR TITLE
Fix several inconsistencies in template handling of arguments and inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,75 +1,71 @@
 name: test
-on:
-  pull_request:
-  push:
-    branches:
-    - master 
+on: { pull_request: {} }
+
 jobs:
-  new:
+  getcidata:
     runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.output.outputs.environments }}
+    steps:
+      - id: output
+        run: |
+          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
+          echo "::set-output name=environments::${envblob}"
+    
+  test-new:
+    needs: getcidata
     strategy:
       fail-fast: false
+      # TODO: This produces 40 checks, that's too many
       matrix:
-        flags:
-          - -n
+        fluentflags:
+          - --no-fluent
           - --fluent.db mysql
           - --fluent.db postgres
           - --fluent.db sqlite
           - --fluent.db mongo
-    container: swift:5.2-focal
+        leafflags:
+          - --leaf
+          - --no-leaf
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     steps:
-      - name: Check out code
+      - name: Select toolchain
+        uses: maxim-lobanov/setup-xcode@v1.2.1
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
+        if: ${{ matrix.env.toolchain != '' }}
+      - name: Install SQLite if needed
+        if: ${{ contains(matrix.fluentflags, 'sqlite') && matrix.env.image != '' }}
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+      - name: Check out toolbox
         uses: actions/checkout@v2
       - name: Build toolbox
-        run: swift build --enable-test-discovery
-      - name: Install toolbox
-        run: mv .build/debug/vapor /usr/bin/vapor
-      - name: New project
-        run: vapor new foo ${{ matrix.flags }} --no-commit
-        working-directory: /tmp
-      - name: Install SQLite
-        if: ${{ contains(matrix.flags, 'sqlite') }}
-        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+        run: swift build --enable-test-discovery -c debug
+      - name: Execute new project command
+        run: |
+          swift run vapor new toolbox-test --no-commit -o /tmp/toolbox-test \
+            ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
       - name: Test new project
-        run: swift test --enable-test-discovery
-        working-directory: /tmp/foo
-  linux:
-    runs-on: ubuntu-latest
+        run: swift test --package-path /tmp/toolbox-test --enable-test-discovery
+  
+  test-toolbox:
+    needs: getcidata
     strategy:
       fail-fast: false
       matrix:
-        image:
-          # 5.2 Stable
-          - swift:5.2-xenial
-          - swift:5.2-bionic
-          - swift:5.2-focal
-          - swift:5.2-centos8
-          - swift:5.2-amazonlinux2
-          # 5.2 Unstable
-          - swiftlang/swift:nightly-5.2-xenial
-          - swiftlang/swift:nightly-5.2-bionic
-          # 5.3 Unstable
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
-          # Master Unstable
-          - swiftlang/swift:nightly-master-xenial
-          - swiftlang/swift:nightly-master-bionic
-          - swiftlang/swift:nightly-master-focal
-          - swiftlang/swift:nightly-master-centos8
-          - swiftlang/swift:nightly-master-amazonlinux2
-    container: ${{ matrix.image }}
+        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     steps:
-      - name: Check out code
+      - name: Select toolchain
+        uses: maxim-lobanov/setup-xcode@v1.2.1
+        with:
+          xcode-version: ${{ matrix.env.toolchain }}
+        if: ${{ matrix.env.toolchain != '' }}
+      - name: Check out toolbox
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
-        run: swift test --enable-test-discovery --sanitize=thread
-  macOS:
-    runs-on: macos-latest
-    steps:
-      - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
-        with: { 'xcode-version': 'latest' }
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
+        timeout-minutes: 20
         run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,10 @@ jobs:
         run: swift build --enable-test-discovery -c debug
       - name: Execute new project command
         run: |
-          swift run vapor new toolbox-test --no-commit -o /tmp/toolbox-test \
-            ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
+          swift run --enable-test-discovery \
+            vapor new toolbox-test \
+                --no-commit -o /tmp/toolbox-test \
+                ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
       - name: Test new project
         run: swift test --package-path /tmp/toolbox-test --enable-test-discovery
   

--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -40,7 +40,7 @@ struct TemplateScaffolder {
             context[variable.name] = .string(value)
             self.console.output(key: variable.name, value: value)
         case .bool:
-            var confirm: Bool
+            let confirm: Bool
             if let index = input.arguments.firstIndex(where: { $0 == "--\(optionName)" }) {
                 input.arguments.remove(at: index)
                 confirm = true
@@ -81,7 +81,7 @@ struct TemplateScaffolder {
             self.console.output(key: variable.name, value: option.name)
             context[variable.name] = .dictionary(option.data.mapValues { .string($0) })
         case .variables(let variables):
-            var confirm: Bool
+            let confirm: Bool
             if input.arguments.contains(where: { $0.hasPrefix("--\(optionName)." )}) {
                 confirm = true
             } else if let index = input.arguments.firstIndex(where: { $0.hasPrefix("--\(optionName)") }) {

--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -40,9 +40,23 @@ struct TemplateScaffolder {
             context[variable.name] = .string(value)
             self.console.output(key: variable.name, value: value)
         case .bool:
-            let value = self.console.confirm("\(variable.description) \("(--\(optionName))", style: .info)")
-            context[variable.name] = .string(value.description)
-            self.console.output(key: variable.name, value: value ? "Yes" : "No")
+            var confirm: Bool
+            if let index = input.arguments.firstIndex(where: { $0 == "--\(optionName)" }) {
+                input.arguments.remove(at: index)
+                confirm = true
+            } else if let index = input.arguments.firstIndex(where: { $0 == "--no-\(optionName)" }) {
+                input.arguments.remove(at: index)
+                confirm = false
+            } else {
+                confirm = self.console.confirm("\(variable.description) \("(--\(optionName)/--no-\(optionName))", style: .info)")
+            }
+            
+            if confirm {
+                context[variable.name] = .string(true.description)
+                self.console.output(key: variable.name, value: "Yes")
+            } else {
+                self.console.output(key: variable.name, value: "No")
+            }
         case .options(let options):
             let option: TemplateManifest.Variable.Option
             if let index = input.arguments.firstIndex(where: { $0.hasPrefix("--\(optionName)") }) {
@@ -70,17 +84,20 @@ struct TemplateScaffolder {
             var confirm: Bool
             if input.arguments.contains(where: { $0.hasPrefix("--\(optionName)." )}) {
                 confirm = true
-            } else if let index = input.arguments.firstIndex(where: { $0.hasPrefix("--\(optionName)" )}) {
+            } else if let index = input.arguments.firstIndex(where: { $0.hasPrefix("--\(optionName)") }) {
                 input.arguments.remove(at: index)
                 confirm = true
+            } else if let index = input.arguments.firstIndex(where: { $0 == "--no-\(optionName)" }) {
+                input.arguments.remove(at: index)
+                confirm = false
             } else {
-                confirm = self.console.confirm("\(variable.description) \("(--\(optionName))", style: .info)")
+                confirm = self.console.confirm("\(variable.description) \("(--\(optionName)/--no-\(optionName))", style: .info)")
             }
             if confirm {
                 self.console.output(key: variable.name, value: "Yes")
                 var nested: [String: MustacheData] = [:]
                 for child in variables {
-                    try self.ask(variable: child, to: &nested, using: &input, prefix: "\(variable.name).")
+                    try self.ask(variable: child, to: &nested, using: &input, prefix: "\(prefix)\(variable.name).")
                 }
                 context[variable.name] = .dictionary(nested)
             } else {


### PR DESCRIPTION
### User-visible changes

- Simple boolean flags in the template, such as `--leaf`, now work, and have negating forms, e.g. `--no-leaf`. Complex nested variables such as `--fluent` now also have a negating form. The intent is that automation is no longer limited to the catch-all `--yes` or `--no` overrides and thus can express non-trivial configurations such as "Leaf but not Fluent". (Note: This was not a significant issue until the template manifest started asking more than one yes/no question per invocation, but with the addition of Leaf support pending in vapor/template#44, such is now the case.)

### Implementation changes

- `.bool` variables specified in a manifest are now only defined in the resulting context if they would have the value `true`. This fixes `if: someboolvar` always being treated as `true` regardless of its actual value (`if:` is an "exists" check, not a "boolean true value" check).

- Prepend the input prefix to all recursive invocations of `ask()` so that, in theory, multiply-nested variables in manifests would work (this functionality is untested and probably has other issues; I pretty much just tossed this fix in for correctness' sake).
