### PR TITLE
Add Kebab case support to TemplateScaffolder context

### DIFF
--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -6,7 +6,7 @@ import Mustache
 struct TemplateScaffolder {
     let console: Console
     let manifest: TemplateManifest
-    
+
     init(console: Console, manifest: TemplateManifest) {
         self.console = console
         self.manifest = manifest
@@ -30,7 +30,7 @@ struct TemplateScaffolder {
 
     private func ask(
         variable: TemplateManifest.Variable,
-        to context: inout [String: MustacheData], 
+        to context: inout [String: MustacheData],
         using input: inout CommandInput,
         prefix: String = ""
     ) throws {
@@ -51,7 +51,7 @@ struct TemplateScaffolder {
             } else {
                 confirm = self.console.confirm("\(variable.description) \("(--\(optionName)/--no-\(optionName))", style: .info)")
             }
-            
+
             if confirm {
                 context[variable.name] = .string(true.description)
                 self.console.output(key: variable.name, value: "Yes")
@@ -68,7 +68,7 @@ struct TemplateScaffolder {
                 let name = input.arguments[next]
                 input.arguments.remove(at: next)
                 input.arguments.remove(at: index)
-                guard let found = options.filter({ 
+                guard let found = options.filter({
                     $0.name.lowercased().hasPrefix(name.lowercased())
                 }).first else {
                     throw "No --\(optionName) option matching '\(name)'"
@@ -124,7 +124,7 @@ struct TemplateScaffolder {
                 }
             }
         }
-        
+
         switch file.type {
         case .file(let dynamic):
             self.console.output("+ " + file.name.consoleText())

--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -17,6 +17,7 @@ struct TemplateScaffolder {
         assert(destination.hasPrefix("/"))
         var context: [String: MustacheData] = [:]
         context["name"] = .string(name)
+        context["name_lower_kabab"] = .string(name.replacingOccurrences(of: " ", with: "-").lowercased())
         self.console.output(key: "name", value: name)
         for variable in self.manifest.variables {
             try self.ask(variable: variable, to: &context, using: &input)

--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -17,7 +17,7 @@ struct TemplateScaffolder {
         assert(destination.hasPrefix("/"))
         var context: [String: MustacheData] = [:]
         context["name"] = .string(name)
-        context["name_kebab"] = .string(name.kebabed())
+        context["name_kebab"] = .string(name.kebabcased())
         self.console.output(key: "name", value: name)
         for variable in self.manifest.variables {
             try self.ask(variable: variable, to: &context, using: &input)
@@ -153,18 +153,11 @@ struct TemplateScaffolder {
 }
 
 fileprivate extension StringProtocol {
-    func kebabed() -> String {
-        var output: String = self.first!.lowercased()
-        for char in self.dropFirst() {
-            if char.isWhitespace {
-                output.append("-")
-            } else if char.isUppercase {
-                output.append("-\(char.lowercased())")
-            } else {
-                output.append(char)
-            }
-        }
-        return output
+    func kebabcased() -> String {
+        return .init(self
+            .flatMap { $0.isWhitespace ? "-" : "\($0)" }
+            .enumerated().flatMap { $0 > 0 && $1.isUppercase ? "-\($1.lowercased())" : "\($1.lowercased())" }
+        )
     }
 }
 

--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -17,7 +17,7 @@ struct TemplateScaffolder {
         assert(destination.hasPrefix("/"))
         var context: [String: MustacheData] = [:]
         context["name"] = .string(name)
-        context["name_lower_kabab"] = .string(name.replacingOccurrences(of: " ", with: "-").lowercased())
+        context["name_kebab"] = .string(name.kebabed())
         self.console.output(key: "name", value: name)
         for variable in self.manifest.variables {
             try self.ask(variable: variable, to: &context, using: &input)
@@ -149,6 +149,22 @@ struct TemplateScaffolder {
                 )
             }
         }
+    }
+}
+
+fileprivate extension StringProtocol {
+    func kebabed() -> String {
+        var output: String = self.first!.lowercased()
+        for char in self.dropFirst() {
+            if char.isWhitespace {
+                output.append("-")
+            } else if char.isUppercase {
+                output.append("-\(char.lowercased())")
+            } else {
+                output.append(char)
+            }
+        }
+        return output
     }
 }
 


### PR DESCRIPTION
This adds support for `kebab_names` in templates to avoid issues where certain contexts require lowercase variables (such as Docker compose).

Fixes #334