### PR TITLE
Fix incorrect default branch name 

### DIFF
--- a/Sources/VaporToolbox/New/New.swift
+++ b/Sources/VaporToolbox/New/New.swift
@@ -36,7 +36,7 @@ struct New: AnyCommand {
 
         context.console.info("Cloning template...")
         try? FileManager.default.removeItem(atPath: templateTree)
-        let gitBranch = signature.templateBranch ?? "master"
+        let gitBranch = signature.templateBranch ?? "main"
         _ = try Process.git.clone(repo: gitUrl, toFolder: templateTree, branch: gitBranch)
 
         if FileManager.default.fileExists(atPath: templateTree.appendingPathComponents("manifest.yml")) {


### PR DESCRIPTION
When we try to create a new app with the toolbox in the code we fallback to a default branch name 'master', however it is now changed to 'main'. This change merely fixes that issue.