### PR TITLE
fix default template branch

### DIFF
--- a/Sources/VaporToolbox/New/New.swift
+++ b/Sources/VaporToolbox/New/New.swift
@@ -36,7 +36,7 @@ struct New: AnyCommand {
 
         context.console.info("Cloning template...")
         try? FileManager.default.removeItem(atPath: templateTree)
-        let gitBranch = signature.templateBranch ?? "master"
+        let gitBranch = signature.templateBranch ?? "main"
         _ = try Process.git.clone(repo: gitUrl, toFolder: templateTree, branch: gitBranch)
 
         if FileManager.default.fileExists(atPath: templateTree.appendingPathComponents("manifest.yml")) {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Use main as a default template branch instead of master.
<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
