### PR TITLE
Fixed help text.

### DIFF
--- a/Sources/VaporToolbox/Heroku/Heroku.swift
+++ b/Sources/VaporToolbox/Heroku/Heroku.swift
@@ -10,6 +10,6 @@ struct Heroku: CommandGroup {
     }
 
     var help: String {
-        "Commands for working with Heroku"
+        "Commands for working with Heroku."
     }
 }

--- a/Sources/VaporToolbox/Supervisor/Supervisor.swift
+++ b/Sources/VaporToolbox/Supervisor/Supervisor.swift
@@ -10,6 +10,6 @@ struct Supervisor: CommandGroup {
     }
 
     var help: String {
-        "Commands for working with Supervisord"
+        "Commands for working with supervisord."
     }
 }


### PR DESCRIPTION
Just two very minor changes:

- added punctuation to Heroku/supervisord to match the other lines
- changed `Supervisord` to `supervisord` to match how it is used on the supervisord web-site

Tested the changes by building the toolbox.