### PR TITLE
Changing info screen to instruct user to open Package.swift

### DIFF
--- a/Sources/VaporToolbox/New/New.swift
+++ b/Sources/VaporToolbox/New/New.swift
@@ -96,7 +96,7 @@ struct New: AnyCommand {
             "Project " + name.consoleText(.info) + " has been created!",
             "",
             "Use " + "cd \(Process.shell.escapeshellarg(cdInstruction))".consoleText(.info) + " to enter the project directory",
-            "Use " + "\(CommandLine.arguments[0]) xcode".consoleText(.info) + " to open the project in Xcode",
+            "Use " + "open \(Process.shell.escapeshellarg(cdInstruction))/Package.swift".consoleText(.info) + " to open the project in Xcode",
         ]).forEach { context.console.output($0) }
     }
 

--- a/Sources/VaporToolbox/New/New.swift
+++ b/Sources/VaporToolbox/New/New.swift
@@ -96,7 +96,7 @@ struct New: AnyCommand {
             "Project " + name.consoleText(.info) + " has been created!",
             "",
             "Use " + "cd \(Process.shell.escapeshellarg(cdInstruction))".consoleText(.info) + " to enter the project directory",
-            "Use " + "open \(Process.shell.escapeshellarg(cdInstruction))/Package.swift".consoleText(.info) + " to open the project in Xcode",
+            "Then use " + "open Package.swift".consoleText(.info) + " to open the project in Xcode",
         ]).forEach { context.console.output($0) }
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Changed the instruction to use "vapor xcode" to instead be "open Package.swift", as is described in Vapor 4 docs

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
