### PR TITLE
Removed deprecated --enable-test-discovery flag from build and run commands

### DIFF
--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -7,7 +7,14 @@ struct Build: AnyCommand {
 
     func run(using context: inout CommandContext) throws {
         context.console.output("Building project...")
-        try exec(Process.shell.which("swift"), ["build"] + context.input.arguments)
+        
+        var flags = [String]()
+        
+        if isEnableTestDiscoveryFlagNeeded() {
+            flags.append("--enable-test-discovery")
+        }
+        
+        try exec(Process.shell.which("swift"), ["build"] + flags + context.input.arguments)
         context.console.info("Project built.")
     }
 }

--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -7,7 +7,7 @@ struct Build: AnyCommand {
 
     func run(using context: inout CommandContext) throws {
         context.console.output("Building project...")
-        try exec(Process.shell.which("swift"), ["build", "--enable-test-discovery"] + context.input.arguments)
+        try exec(Process.shell.which("swift"), ["build"] + context.input.arguments)
         context.console.info("Project built.")
     }
 }

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -3,14 +3,19 @@ import Foundation
 
 // Generates an Xcode project
 struct Run: AnyCommand {
-    let help = "Runs an app from the console.\nEquivalent to `swift run Run`."
+    let help = "Runs an app from the console.\nEquivalent to `swift run Run`.\nThe --enable-test-discovery flag is automatically set if needed."
 
     func run(using context: inout CommandContext) throws {
+        var flags = [String]()
+        if isEnableTestDiscoveryFlagNeeded() {
+            flags.append("--enable-test-discovery")
+        }
+        
         var extraArguments: [String] = []
         if let confirmOverride = context.console.confirmOverride {
             extraArguments.append(confirmOverride ? "--yes" : "--no")
         }
-        try exec(Process.shell.which("swift"), ["run", "Run"] + context.input.arguments + extraArguments)
+        try exec(Process.shell.which("swift"), ["run"] + flags + ["Run"] + context.input.arguments + extraArguments)
     }
 
     func outputHelp(using context: inout CommandContext) {

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -3,14 +3,14 @@ import Foundation
 
 // Generates an Xcode project
 struct Run: AnyCommand {
-    let help = "Runs an app from the console.\nEquivalent to `swift run --enable-test-discovery Run`."
+    let help = "Runs an app from the console.\nEquivalent to `swift run Run`."
 
     func run(using context: inout CommandContext) throws {
         var extraArguments: [String] = []
         if let confirmOverride = context.console.confirmOverride {
             extraArguments.append(confirmOverride ? "--yes" : "--no")
         }
-        try exec(Process.shell.which("swift"), ["run", "--enable-test-discovery", "Run"] + context.input.arguments + extraArguments)
+        try exec(Process.shell.which("swift"), ["run", "Run"] + context.input.arguments + extraArguments)
     }
 
     func outputHelp(using context: inout CommandContext) {

--- a/Tests/VaporToolboxTests/VaporToolboxTests.swift
+++ b/Tests/VaporToolboxTests/VaporToolboxTests.swift
@@ -2,9 +2,30 @@
 import XCTest
 
 final class VaporToolboxTests: XCTestCase {
-
+    
     func testStub() throws {
         XCTAssertTrue(true)
     }
-
+    
+    /// Assures that when Swift version can be detected it produces the right result.
+    /// - Note: As this test relies on conditional compilation it can only test one specific version (the one which is currently compiling the test).
+    func testSwiftVersionDetection() throws {
+        if let version = RuntimeSwiftVersion() {
+#if swift(>=5.5)
+            XCTAssertTrue(version.major > 5 || (version.major == 5 && version.minor >= 5))
+#elseif swift(>=5.4)
+            XCTAssertTrue(version.major == 5 && version.minor == 4)
+#elseif swift(>=5.3)
+            XCTAssertTrue(version.major == 5 && version.minor == 3)
+#elseif swift(>=5.2)
+            XCTAssertTrue(version.major == 5 && version.minor == 2)
+#else
+            XCTAssertTrue( !(version.major > 5 || (version.major == 5 && version.minor >= 2)))
+#endif
+        } else {
+            // Swift version detection may fail but it doesn't cause any wrong result then it should pass the test.
+            XCTAssertTrue(true)
+        }
+    }
+    
 }


### PR DESCRIPTION
Removing this flag fixes a warning which appears every time an app is built or run through the toolbox.

### Current behaviour:
```shell
vapor build
```
Output:
```shell
Building project...
warning: '--enable-test-discovery' option is deprecated; tests are automatically discovered on all platforms
```

The `--enable-test-discovery` flag is not needed anymore as deprecated because now it is the default behaviour.
