### PR TITLE
Bug/update ci Update CI to run only with swift 5.2 and swift 5.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,12 @@
 name: test
+on: 
+  push:
+    branches:
+      - bug/updateCI
 #on: { pull_request: {} }
-on: workflow_dispatch
 
-jobs:
-  #test-new-latest:
-    #runs-on: macOS-latest
-    
-  #test-new-5_2:
-    #runs-on: macOS-latest
-  
+
+jobs:  
   # Get OS and Images from a file in the vapor/ci repository
   getcidata:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         leafflags:
           - --leaf
           - --no-leaf
-        os: ['ubuntu-latest', 'macos-latest']
+        os: [ubuntu-latest, macos-latest]
         image: ["swift:5.2-focal", "swift:5.5-focal"]
         env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
     runs-on: ${{ matrix.os }} #matrix.env.os }}
@@ -78,8 +78,8 @@ jobs:
       fail-fast: false
       matrix:
         env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
-    runs-on: ${{ matrix.env.os }}
-    container: ${{ matrix.env.image }}
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.image }}
     steps:
       - name: Select toolchain
         uses: maxim-lobanov/setup-xcode@v1.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: test
 # TODO: Remove for PR once finished
-on: 
-  push:
-    branches:
-      - bug/updateCI
-#on: { pull_request: {} }
+#on: 
+#  push:
+#    branches:
+#      - bug/updateCI
+on: { pull_request: {} }
 
 
 jobs:  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: test
+# TODO: Remove for PR once finished
 on: 
   push:
     branches:
@@ -7,19 +8,7 @@ on:
 
 
 jobs:  
-  # Get OS and Images from a file in the vapor/ci repository
-  getcidata:
-    runs-on: ubuntu-latest
-    outputs:
-      environments: ${{ steps.output.outputs.environments }}
-    steps:
-      - id: output
-        run: |
-          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
-          echo "::set-output name=environments::${envblob}"
-    
   test-new:
-    needs: getcidata
     # Run the workflow on multiple machines
     strategy:
       fail-fast: false
@@ -35,34 +24,20 @@ jobs:
         leafflags:
           - --leaf
           - --no-leaf
-        os: [macos-latest]
-        image: ["swift:5.2-focal", "swift:5.5-focal"]
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+        os: [ubuntu-latest]
+        image: ["swift:5.5-focal"]
     # Run on the given operating system and image
     runs-on: ${{ matrix.os }} #matrix.env.os }}
     container: ${{ matrix.image }} #matrix.env.image }}
     steps:
-      - name: Select toolchain
-        uses: maxim-lobanov/setup-xcode@v1.2.1
-        with:
-          xcode-version: ${{ matrix.env.toolchain }}
-        if: ${{ matrix.env.toolchain != '' }}
       - name: Install SQLite if needed
-        if: ${{ contains(matrix.fluentflags, 'sqlite') && matrix.env.image != '' }}
+        if: ${{ contains(matrix.fluentflags, 'sqlite') }}
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out toolbox
         uses: actions/checkout@v2
       - name: Build toolbox
         run: swift build --enable-test-discovery -c debug
-      - name: Execute new project command 5.2
-        if: ${{ matrix.image == 'swift:5.2-focal' }}
-        run: |
-          swift run --enable-test-discovery \
-            vapor new toolbox-test --branch version/5.2 \
-                --no-commit -o /tmp/toolbox-test \
-                ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
-      - name: Execute new project command 5.5
-        if: ${{ matrix.image == 'swift:5.5-focal' }}
+      - name: Execute new project command
         run: |
           swift run --enable-test-discovery \
             vapor new toolbox-test \
@@ -72,11 +47,14 @@ jobs:
         run: swift test --package-path /tmp/toolbox-test --enable-test-discovery
   
   test-toolbox:
-    needs: getcidata
     strategy:
       fail-fast: false
       matrix:
-        env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+        env: ${{ fromJSON([
+            {\"os\":\"ubuntu-latest\", \"image\":\"swift:5.2-focal\", \"toolchain\":null},
+            {\"os\":\"ubuntu-latest\", \"image\":\"swift:5.5-focal\", \"toolchain\":null},
+            {\"os\":\"macos-11\", \"image\":null, \"toolchain\":\"latest\"}]) 
+          }}
     runs-on: ${{ matrix.env.os }}
     container: ${{ matrix.env.image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: test
-on: { pull_request: {} }
+#on: { pull_request: {} }
+on: workflow_dispatch
 
 jobs:
   #test-new-latest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,12 @@ name: test
 on: { pull_request: {} }
 
 jobs:
+  #test-new-latest:
+    #runs-on: macOS-latest
+    
+  #test-new-5_2:
+    #runs-on: macOS-latest
+  
   getcidata:
     runs-on: ubuntu-latest
     outputs:
@@ -27,9 +33,11 @@ jobs:
         leafflags:
           - --leaf
           - --no-leaf
+        os: ['ubuntu-latest', 'macos-latest']
+        image: ["swift:5.2-focal", "swift:5.5-focal"]
         env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
-    runs-on: ${{ matrix.env.os }}
-    container: ${{ matrix.env.image }}
+    runs-on: ${{ matrix.os }} #matrix.env.os }}
+    container: ${{ matrix.image }} #matrix.env.image }}
     steps:
       - name: Select toolchain
         uses: maxim-lobanov/setup-xcode@v1.2.1
@@ -41,9 +49,21 @@ jobs:
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out toolbox
         uses: actions/checkout@v2
-      - name: Build toolbox
+      - name: Build toolbox 5.2
+        if: ${{ matrix.image == 'swift:5.2-focal' }}
         run: swift build --enable-test-discovery -c debug
-      - name: Execute new project command
+      - name: Build toolbox 5.5
+        if: ${{ matrix.image == 'swift:5.5-focal' }}
+        run: swift build -c debug
+      - name: Execute new project command 5.2
+        if: ${{ matrix.image == 'swift:5.2-focal' }}
+        run: |
+          swift run --enable-test-discovery \
+            vapor new toolbox-test --branch version/5.2 \
+                --no-commit -o /tmp/toolbox-test \
+                ${{ matrix.fluentflags }} ${{ matrix.leafflags }}
+      - name: Execute new project command 5.5
+        if: ${{ matrix.image == 'swift:5.5-focal' }}
         run: |
           swift run --enable-test-discovery \
             vapor new toolbox-test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
   #test-new-5_2:
     #runs-on: macOS-latest
   
+  # Get OS and Images from a file in the vapor/ci repository
   getcidata:
     runs-on: ubuntu-latest
     outputs:
@@ -21,9 +22,11 @@ jobs:
     
   test-new:
     needs: getcidata
+    # Run the workflow on multiple machines
     strategy:
       fail-fast: false
       # TODO: This produces 40 checks, that's too many
+      # Setup flags to be used in the vapor new command as well as operating systems with images
       matrix:
         fluentflags:
           - --no-fluent
@@ -34,9 +37,10 @@ jobs:
         leafflags:
           - --leaf
           - --no-leaf
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
         image: ["swift:5.2-focal", "swift:5.5-focal"]
         env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
+    # Run on the given operating system and image
     runs-on: ${{ matrix.os }} #matrix.env.os }}
     container: ${{ matrix.image }} #matrix.env.image }}
     steps:
@@ -50,12 +54,8 @@ jobs:
         run: apt-get -q update && apt-get -q install -y libsqlite3-dev
       - name: Check out toolbox
         uses: actions/checkout@v2
-      - name: Build toolbox 5.2
-        if: ${{ matrix.image == 'swift:5.2-focal' }}
+      - name: Build toolbox
         run: swift build --enable-test-discovery -c debug
-      - name: Build toolbox 5.5
-        if: ${{ matrix.image == 'swift:5.5-focal' }}
-        run: swift build -c debug
       - name: Execute new project command 5.2
         if: ${{ matrix.image == 'swift:5.2-focal' }}
         run: |
@@ -79,8 +79,8 @@ jobs:
       fail-fast: false
       matrix:
         env: ${{ fromJSON(needs.getcidata.outputs.environments) }}
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.image }}
+    runs-on: ${{ matrix.env.os }}
+    container: ${{ matrix.env.image }}
     steps:
       - name: Select toolchain
         uses: maxim-lobanov/setup-xcode@v1.2.1


### PR DESCRIPTION
Update the workflow to only test for swift 5.2 and swift 5.5 releases.

Use the branched template to test with the 5.2 release.


This draft is for testing purposes only
It should close #374 eventually
