### PR TITLE
Improve the messaging for the version command

### DIFF
--- a/Sources/VaporToolbox/Toolbox.swift
+++ b/Sources/VaporToolbox/Toolbox.swift
@@ -58,11 +58,11 @@ final class Toolbox: CommandGroup {
                 context.console.output(key: "framework", value: vapor.state.version)
             } else {
                 context.console.output("\("note:", style: .warning) this Swift project does not depend on Vapor.")
-                context.console.output(key: "framework", value: "not found")
+                context.console.output(key: "framework", value: "vapor framework for this project: this Swift project does not depend on Vapor. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
             }
         } catch {
-            context.console.output("\("note:", style: .warning) no Package.resolved file was found.")
-            context.console.output(key: "framework", value: "not found")
+            context.console.output("\("note:", style: .warning) no Package.resolved file was found. Possibly not currently in a Swift package directory")
+            context.console.output(key: "framework", value: "vapor framework for this project: no Package.resolved file found. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
         }
     }
 

--- a/Sources/VaporToolbox/Toolbox.swift
+++ b/Sources/VaporToolbox/Toolbox.swift
@@ -58,11 +58,11 @@ final class Toolbox: CommandGroup {
                 context.console.output(key: "framework", value: vapor.state.version)
             } else {
                 context.console.output("\("note:", style: .warning) this Swift project does not depend on Vapor.")
-                context.console.output(key: "framework", value: "vapor framework for this project: this Swift project does not depend on Vapor. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
+                context.console.output(key: "framework", value: "Vapor framework for this project: this Swift project does not depend on Vapor. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
             }
         } catch {
             context.console.output("\("note:", style: .warning) no Package.resolved file was found. Possibly not currently in a Swift package directory")
-            context.console.output(key: "framework", value: "vapor framework for this project: no Package.resolved file found. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
+            context.console.output(key: "framework", value: "Vapor framework for this project: no Package.resolved file found. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with `swift build`. You can create a new project with `vapor new MyProject`")
         }
     }
 


### PR DESCRIPTION
When using _vapor --version_, the output in a non vapor directory would be
```bash
# note: no Package.resolved was found.
# framework: not found
# toolbox: 18.3.3
```

This pr changes those framework and note texts to:
```bash
# note: no Package.resolved file was found. Possibly not currently in a Swift package directory
# framework: vapor framework for this project: no Package.resolved file found. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with 'swift build'. You can create a new project with 'vapor new MyProject'
```
in projects that have no Package.resolved.
in projects that do have a Package.resolved but that aren't Vapor projects it changes the framework text to:
```bash
# framework: vapor framework for this project: this Swift project does not depend on Vapor. Please ensure you are in a Vapor project directory. If you are, ensure you have built the project with 'swift build'. You can create a new project with 'vapor new MyProject'
```

closes #345 