### PR TITLE
Update Yams dependency to "from: 4.0.0"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/tanner0101/mustache.git", from: "0.1.0"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.2.0"),
     ],


### PR DESCRIPTION
[Manually building](https://github.com/Homebrew/homebrew-core/blob/b7824316b8c6d4488c5b84a758b15d02a9e99e12/Formula/vapor.rb#L20-L21) `toolbox-18.3.5` on macOS logs the following compiler warnings:

```
Working copy of https://github.com/jpsim/Yams.git resolved at 2.0.0
/Users/daniel/Downloads/toolbox-18.3.5/.build/checkouts/Yams/Sources/Yams/Emitter.swift:338:32: warning: initialization of 'UnsafeMutablePointer<yaml_version_directive_t>' (aka 'UnsafeMutablePointer<yaml_version_directive_s>') results in a dangling pointer
            versionDirective = UnsafeMutablePointer(&versionDirectiveValue)
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/daniel/Downloads/toolbox-18.3.5/.build/checkouts/Yams/Sources/Yams/Emitter.swift:338:53: note: implicit argument conversion from 'yaml_version_directive_t' (aka 'yaml_version_directive_s') to 'UnsafeMutablePointer<yaml_version_directive_t>' (aka 'UnsafeMutablePointer<yaml_version_directive_s>') produces a pointer valid only for the duration of the call to 'init(_:)'
            versionDirective = UnsafeMutablePointer(&versionDirectiveValue)
                                                    ^~~~~~~~~~~~~~~~~~~~~~
/Users/daniel/Downloads/toolbox-18.3.5/.build/checkouts/Yams/Sources/Yams/Emitter.swift:338:53: note: use 'withUnsafeMutablePointer' in order to explicitly convert argument to pointer valid for a defined scope
            versionDirective = UnsafeMutablePointer(&versionDirectiveValue)
```

This issue was solved in [Yams v3.0](https://github.com/jpsim/Yams/releases/tag/3.0.0), almost 2 years ago. Looking through the version history, there are other bug fixes, which may/may not have any impact on vapor.

Given that `vapor`'s documentation says Swift 5.2+ is required, and Yams v4 only requires 5.1+ (but Yams v5 requires 5.4+), this feels like a good dependency update to make.

I wasn't able to do a great job testing this, but I think it's working correctly.

-  It compiles and runs for me.
- `vapor new` works with the default template. 
- I only found one other template that uses a `manifest.yml` when searching for [vapor + template topics]() (per [recommendation](https://github.com/vapor/docs/blob/78e7c8e357fc712c8b93f46bdd96f466e8430e6d/3.0/docs/getting-started/toolbox.md?plain=1#L50) in older versions of the docs). [That template](https://www.github.com/nodes-vapor/template) also works.

This seems to be the only usage of Yams in the toolbox, that I could find. https://github.com/vapor/toolbox/blob/5ffe48fb4023794f6d414b540d64127c2c44656d/Sources/VaporToolbox/New/New.swift#L32-L45