### PR TITLE
Remove backslash from Procfile created by `vapor heroku init`

### DIFF
--- a/Sources/VaporToolbox/Heroku/HerokuInit.swift
+++ b/Sources/VaporToolbox/Heroku/HerokuInit.swift
@@ -8,7 +8,7 @@ build:
 """
 
 let herokuProcfile = """
-web: Run serve --env production --hostname 0.0.0.0 --port \\$PORT
+web: Run serve --env production --hostname 0.0.0.0 --port $PORT
 """
 
 struct HerokuInit: Command {


### PR DESCRIPTION
Running `vapor heroku init`, and choosing to use the buildpack (vs docker), creates a Procfile with the following:

```
web: Run serve --env production --hostname 0.0.0.0 --port \$PORT
```

This works okay when deployed to heroku (note the `--port \4386`):
```
2022-03-08T07:07:33.775125+00:00 heroku[web.1]: Starting process with command `Run serve --env production --hostname 0.0.0.0 --port \4386`
2022-03-08T07:07:35.820116+00:00 app[web.1]: [ NOTICE ] Server starting on http://0.0.0.0:4386
```

However, it doesn't work when using the `heroku local` command:
```
$ heroku local
10:54:26 PM web.1 |  [1/1] Planning build
10:54:31 PM web.1 |  [0/0] Build complete!
10:54:31 PM web.1 |  [ WARNING ] Could not convert option for `port` to Int
10:54:31 PM web.1 |  Swift/ErrorType.swift:200: Fatal error: Error raised at top level: .invalidOptionType("port", type: Int)
[DONE] Killing all processes with signal  SIGILL
10:54:31 PM web.1 Exited with exit code SIGILL
```

----

This PR removes the backslash. The new Procfile contents are simply:
```
web: Run serve --env production --hostname 0.0.0.0 --port $PORT
```

I've verified this works with heroku remote & local. 
```
2022-03-08T07:18:31.543631+00:00 heroku[web.1]: Starting process with command `Run serve --env production --hostname 0.0.0.0 --port 32664`
2022-03-08T07:18:32.671361+00:00 app[web.1]: [ NOTICE ] Server starting on http://0.0.0.0:32664
2022-03-08T07:18:33.310530+00:00 heroku[web.1]: State changed from starting to up
2022-03-08T07:19:57.000000+00:00 app[api]: Build succeeded
```