### PR TITLE
Allow dynamic file names in template manifest

### DIFF
--- a/Sources/VaporToolbox/New/TemplateScaffolder.swift
+++ b/Sources/VaporToolbox/New/TemplateScaffolder.swift
@@ -125,9 +125,11 @@ struct TemplateScaffolder {
             }
         }
         
+        let renderer = MustacheRenderer()
+        
         let destinationFileName: String
         if let dynamicName = file.dynamicName {
-            destinationFileName = try MustacheRenderer().render(template: dynamicName, data: context)
+            destinationFileName = try renderer.render(template: dynamicName, data: context)
         } else {
             destinationFileName = file.name
         }
@@ -138,7 +140,7 @@ struct TemplateScaffolder {
             self.console.output("+ " + file.name.consoleText())
             if dynamic {
                 let template = try String(contentsOf: source.appendingPathComponents(file.name).asFileURL, encoding: .utf8)
-                try MustacheRenderer().render(template: template, data: context)
+                try renderer.render(template: template, data: context)
                     .write(to: URL(fileURLWithPath: destinationPath), atomically: true, encoding: .utf8)
             } else {
                 try FileManager.default.moveItem(


### PR DESCRIPTION
By adding `dynamic_name` parameters to files or folders in manifest.yml, their names in the created package can depend on variables or the name of the new package.

Example:

```
- folder: xcschemes
  files:
    - file: Server.xcscheme
      dynamic_name: "{{name}}.xcscheme"
```

In this case, the original name of the file in the template repository is 'Server.xscheme'. In the created package, its name will be '\[Package Name\].xscheme'. The dynamic file name may also depend on variables defined in manifest.yml.