### PR TITLE
Compatibility with official swift container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,20 +7,20 @@ build:
 install: build
 # if uid does not equal 0
 # user is not root and must use sudo
-	ifneq ($(shell id -u), 0)
-		sudo mv .build/release/vapor ${DEST}
-		sudo chmod 755 ${DEST}
+ifneq ($(shell id -u), 0)
+	sudo mv .build/release/vapor ${DEST}
+	sudo chmod 755 ${DEST}
 # if uid is 0
 # user is root and perhaps sudo is not available
-	else
-		mv .build/release/vapor ${DEST}
-		chmod 755 ${DEST}
-	endif
+else
+	mv .build/release/vapor ${DEST}
+	chmod 755 ${DEST}
+endif
 uninstall:
-	ifneq ($(shell id -u), 0)
-		sudo rm ${DEST}
-	else
-		rm ${DEST}
-	endif
+ifneq ($(shell id -u), 0)
+	sudo rm ${DEST}
+else
+	rm ${DEST}
+endif
 clean:
 	rm -rf .build

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ uninstall:
 		sudo rm ${DEST}
 	else
 		rm ${DEST}
-    endif
+	endif
 clean:
 	rm -rf .build

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,22 @@ build:
 	./build
 	rm ./build
 install: build
-	sudo mv .build/release/vapor ${DEST}
-	sudo chmod 755 ${DEST}
+# if uid does not equal 0
+# user is not root and must use sudo
+	ifneq ($(shell id -u), 0)
+		sudo mv .build/release/vapor ${DEST}
+		sudo chmod 755 ${DEST}
+# if uid is 0
+# user is root and perhaps sudo is not available
+	else
+		mv .build/release/vapor ${DEST}
+		chmod 755 ${DEST}
+	endif
 uninstall:
-	sudo rm ${DEST}
+	ifneq ($(shell id -u), 0)
+		sudo rm ${DEST}
+	else
+		rm ${DEST}
+    endif
 clean:
 	rm -rf .build


### PR DESCRIPTION
Sudo is not available in containers, running sudo breaks `make install`. Solve the issue by checking whether the user is root, and if he is, no need to use sudo.

I recommend more testing before merging