### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out toolbox
         uses: actions/checkout@v2
       - name: Build toolbox
-        run: swift build --enable-test-discovery -c debug
+        run: swift build -c debug
       - name: Execute new project command
         run: |
           swift run \
@@ -44,7 +44,7 @@ jobs:
       environments: ${{ steps.output.outputs.environments }}
     steps:
       - id: output
-        run: echo "::set-output name=environments::[{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.2-focal\", \"toolchain\":null},{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.5-focal\", \"toolchain\":null},{\"os\":\"macos-11\", \"image\":null, \"toolchain\":\"latest\"}]"
+        run: echo "::set-output name=environments::[{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.4-focal\", \"toolchain\":null},{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.6-focal\", \"toolchain\":null},{\"os\":\"macos-11\", \"image\":null, \"toolchain\":\"latest\"}]"
   
   test-toolbox:
     needs: createJSON
@@ -64,4 +64,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer
         timeout-minutes: 20
-        run: swift test --enable-test-discovery --sanitize=thread
+        run: swift test --sanitize=thread

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM swift:5.2-bionic as build
+FROM swift:5.6-focal as build
 WORKDIR /build
 COPY . .
-RUN swift build --build-path /build/.build --enable-test-discovery -c release
+RUN swift build --build-path /build/.build --static-swift-stdlib -c release
 
-FROM swift:5.2-bionic-slim
+FROM focal
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get -q update && apt-get -q upgrade -y && apt-get install -y --no-install-recommends git \
     && rm -r /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /build
 COPY . .
 RUN swift build --build-path /build/.build --static-swift-stdlib -c release
 
-FROM focal
+FROM ubuntu:focal
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get -q update && apt-get -q upgrade -y && apt-get install -y --no-install-recommends git \
     && rm -r /var/lib/apt/lists/*

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/scripts/build.swift
+++ b/scripts/build.swift
@@ -9,8 +9,7 @@ func build() throws {
             "swift", "build",
             "--disable-sandbox",
             "--configuration", "release",
-            "-Xswiftc", "-cross-module-optimization",
-            "--enable-test-discovery"
+            "-Xswiftc", "-cross-module-optimization"
         )
     }
 }


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)