### PR TITLE
Update Toolbox for new Templates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       environments: ${{ steps.output.outputs.environments }}
     steps:
       - id: output
-        run: echo "::set-output name=environments::[{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.4-focal\", \"toolchain\":null},{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.6-focal\", \"toolchain\":null},{\"os\":\"macos-11\", \"image\":null, \"toolchain\":\"latest\"}]"
+        run: echo "::set-output name=environments::[{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.6-focal\", \"toolchain\":null},{\"os\":\"ubuntu-latest\", \"image\":\"swift:5.8-focal\", \"toolchain\":null},{\"os\":\"macos-13\", \"image\":null, \"toolchain\":\"latest\"}]"
   
   test-toolbox:
     needs: createJSON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           - --leaf
           - --no-leaf
         os: [ubuntu-latest]
-        image: ["swift:5.6-focal"]
+        image: ["swift:5.8-focal"]
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.image }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData
 .swiftpm
 Tests/LinuxMain.swift
 Package.resolved
+.vscode

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .testTarget(name: "VaporToolboxTests", dependencies: [
             .target(name: "VaporToolbox"),
         ]),
-        .target(name: "Executable", dependencies: [
+        .executableTarget(name: "Executable", dependencies: [
             .target(name: "VaporToolbox"),
         ]),
     ]

--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -6,6 +6,8 @@ struct Build: AnyCommand {
     let help = "Builds an app in the console."
 
     func run(using context: inout CommandContext) throws {
+        ctx.console.warning("This command is deprecated. Use `swift build` instead.")
+
         context.console.output("Building project...")
         
         var flags = [String]()

--- a/Sources/VaporToolbox/Build.swift
+++ b/Sources/VaporToolbox/Build.swift
@@ -6,7 +6,7 @@ struct Build: AnyCommand {
     let help = "Builds an app in the console."
 
     func run(using context: inout CommandContext) throws {
-        ctx.console.warning("This command is deprecated. Use `swift build` instead.")
+        context.console.warning("This command is deprecated. Use `swift build` instead.")
 
         context.console.output("Building project...")
         

--- a/Sources/VaporToolbox/Clean.swift
+++ b/Sources/VaporToolbox/Clean.swift
@@ -37,6 +37,8 @@ class Cleaner {
     }
 
     func run() throws {
+        ctx.console.warning("This command is deprecated. Use `swift package clean` instead.")
+
         var ops: [(String, () throws -> CleanResult)] = []
         ops.append((".build", cleanBuildFolder))
         ops.append(("Package.resolved", cleanPackageResolved))

--- a/Sources/VaporToolbox/Heroku/HerokuInit.swift
+++ b/Sources/VaporToolbox/Heroku/HerokuInit.swift
@@ -32,6 +32,8 @@ struct HerokuInit: Command {
     let help = "Configures app for deployment to Heroku."
 
     func run(using ctx: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Use `heroku init` instead.")
+
         // Get Swift package name
         let name = try Process.swift.package.dump().name
         ctx.console.list(key: "Package", value: name)

--- a/Sources/VaporToolbox/Heroku/HerokuPush.swift
+++ b/Sources/VaporToolbox/Heroku/HerokuPush.swift
@@ -8,7 +8,7 @@ struct HerokuPush: Command {
     let help = "Deploys app to Heroku."
 
     func run(using context: CommandContext, signature: Signature) throws {
-        ctx.console.warning("This command is deprecated. Use `git push heroku <branch>` instead.")
+        context.console.warning("This command is deprecated. Use `git push heroku <branch>` instead.")
 
         // Get Swift package name
         let name = try Process.swift.package.dump().name

--- a/Sources/VaporToolbox/Heroku/HerokuPush.swift
+++ b/Sources/VaporToolbox/Heroku/HerokuPush.swift
@@ -8,6 +8,8 @@ struct HerokuPush: Command {
     let help = "Deploys app to Heroku."
 
     func run(using context: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Use `git push heroku <branch>` instead.")
+
         // Get Swift package name
         let name = try Process.swift.package.dump().name
         context.console.list(key: "Package", value: name)

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -3,9 +3,11 @@ import Foundation
 
 // Generates an Xcode project
 struct Run: AnyCommand {
-    let help = "Runs an app from the console.\nEquivalent to `swift run Run`.\nThe --enable-test-discovery flag is automatically set if needed."
+    let help = "Runs an app from the console.\nEquivalent to `swift run App`.\nThe --enable-test-discovery flag is automatically set if needed."
 
     func run(using context: inout CommandContext) throws {
+        ctx.console.warning("This command is deprecated. Use `swift run App` instead.")
+
         var flags = [String]()
         if isEnableTestDiscoveryFlagNeeded() {
             flags.append("--enable-test-discovery")

--- a/Sources/VaporToolbox/Run.swift
+++ b/Sources/VaporToolbox/Run.swift
@@ -24,14 +24,17 @@ struct Run: AnyCommand {
         let urlString = FileManager.default.currentDirectoryPath.trailingSlash.appendingPathComponents(filename)
         let manifestContents: String
         
-        guard let url = URL(string: urlString) else {
+        guard let url = URL(string: "file://\(urlString)") else {
             throw "Invalid URL: \(urlString)"   
         }
+
+        context.console.info("Reading file at \(urlString)")
         
         do {
             manifestContents = try String(contentsOf: url, encoding: .utf8)
         } catch {
             context.console.error("Failed to read manifest - are you in the correct directory?")
+            context.console.error("\(error)")
             return
         }
 
@@ -40,6 +43,8 @@ struct Run: AnyCommand {
         } else {
             appName = "App"
         }
+
+        context.console.info("Running \(appName)...")
 
         try exec(Process.shell.which("swift"), ["run"] + flags + [appName] + context.input.arguments + extraArguments)
     }

--- a/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
@@ -11,13 +11,15 @@ struct SupervisorInit: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Follow the docs for the latest instructions at https://docs.vapor.codes/deploy/supervisor/")
+
         let package = try Process.swift.package.dump()
         let cwd = FileManager.default.currentDirectoryPath
         let user = NSUserName()
         let config = SupervisorConfiguration(
             program: package.name,
             attributes: [
-                "command": "\(cwd)/.build/release/Run serve --env production",
+                "command": "\(cwd)/.build/release/App serve --env production",
                 "directory": cwd,
                 "user": user,
                 "stdout_logfile": "/var/log/supervisor/\(package.name)-stdout.log",

--- a/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorInit.swift
@@ -11,7 +11,7 @@ struct SupervisorInit: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
-        ctx.console.warning("This command is deprecated. Follow the docs for the latest instructions at https://docs.vapor.codes/deploy/supervisor/")
+        context.console.warning("This command is deprecated. Follow the docs for the latest instructions at https://docs.vapor.codes/deploy/supervisor/")
 
         let package = try Process.swift.package.dump()
         let cwd = FileManager.default.currentDirectoryPath

--- a/Sources/VaporToolbox/Supervisor/SupervisorRestart.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorRestart.swift
@@ -10,7 +10,7 @@ struct SupervisorRestart: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
-        ctx.console.warning("This command is deprecated. Use `supervisorctl restart <AppName>` instead.")
+        context.console.warning("This command is deprecated. Use `supervisorctl restart <AppName>` instead.")
 
         let package = try Process.swift.package.dump()
         context.console.print("Restarting \(package.name).")

--- a/Sources/VaporToolbox/Supervisor/SupervisorRestart.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorRestart.swift
@@ -10,6 +10,8 @@ struct SupervisorRestart: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Use `supervisorctl restart <AppName>` instead.")
+
         let package = try Process.swift.package.dump()
         context.console.print("Restarting \(package.name).")
         try Process.run(Process.shell.which("supervisorctl"), "restart", package.name)

--- a/Sources/VaporToolbox/Supervisor/SupervisorUpdate.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorUpdate.swift
@@ -10,7 +10,7 @@ struct SupervisorUpdate: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
-        ctx.console.warning("This command is deprecated. Use `supervisorctl update <AppName>` instead.")
+        context.console.warning("This command is deprecated. Use `supervisorctl update <AppName>` instead.")
 
         let package = try Process.swift.package.dump()
         try Process.run(Process.shell.which("supervisorctl"), "update", package.name)

--- a/Sources/VaporToolbox/Supervisor/SupervisorUpdate.swift
+++ b/Sources/VaporToolbox/Supervisor/SupervisorUpdate.swift
@@ -10,6 +10,8 @@ struct SupervisorUpdate: Command {
     }
 
     func run(using context: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Use `supervisorctl update <AppName>` instead.")
+
         let package = try Process.swift.package.dump()
         try Process.run(Process.shell.which("supervisorctl"), "update", package.name)
         context.console.info("Supervisor entry for \(package.name) updated.")

--- a/Sources/VaporToolbox/Xcode/Xcode.swift
+++ b/Sources/VaporToolbox/Xcode/Xcode.swift
@@ -12,6 +12,8 @@ struct Xcode: Command {
     
     /// See `Command`.
     func run(using ctx: CommandContext, signature: Signature) throws {
+        ctx.console.warning("This command is deprecated. Use `open Package.swift` or `code .` instead.")
+
         ctx.console.info("Opening project in Xcode.")
         do {
             #if os(macOS)


### PR DESCRIPTION
* Bumps the minimum required Swift version to 5.6 to match SwiftNIO
* Adds deprecation warnings to all the old commands
* Handle the new Vapor templates with a different executable name (you should still use `swift run` anyway)