### PR TITLE
Use the new updated Mustache package from vapor-community

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "mustache",
-        "repositoryURL": "https://github.com/tanner0101/mustache.git",
+        "repositoryURL": "https://github.com/vapor-community/mustache.git",
         "state": {
           "branch": null,
-          "revision": "d98546e8b8d3287d69391ecddeb5732980986eef",
-          "version": "0.1.1"
+          "revision": "052c0946ab54c3c850eaf1ee1ef58630b7ef3f78",
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),
-        .package(url: "https://github.com/tanner0101/mustache.git", from: "0.1.0"),
+        .package(url: "https://github.com/vapor-community/mustache.git", from: "0.2.0"),
         .package(url: "https://github.com/vapor/console-kit.git", from: "4.2.0"),
     ],
     targets: [


### PR DESCRIPTION
This fixes building the toolbox on Arch Linux and uses a much newer version of the `mustach` parser for good measure.