### PR TITLE
Sanitize the project name if it is invalid to use for Swift targets, files or types

### DIFF
--- a/Sources/VaporToolbox/TemplateRenderer.swift
+++ b/Sources/VaporToolbox/TemplateRenderer.swift
@@ -232,9 +232,12 @@ extension String {
 
     /// A Boolean value indicating whether the string is a valid name for a Swift target, file or type.
     var isValidName: Bool {
-        self.wholeMatch(of: #/
-            (?:\p{L}|_)         # match Letter or underscore
-            (?:\p{L}|\p{N}|_)*  # match zero or more Letters, Numbers, and/or underscores
-        /#) != nil
+        self.wholeMatch(
+            of:
+                #/
+                (?:\p{L}|_)         # match Letter or underscore
+                (?:\p{L}|\p{N}|_)*  # match zero or more Letters, Numbers, and/or underscores
+                /#
+        ) != nil
     }
 }

--- a/Sources/VaporToolbox/TemplateRenderer.swift
+++ b/Sources/VaporToolbox/TemplateRenderer.swift
@@ -232,8 +232,9 @@ extension StringProtocol {
 
     /// A Boolean value indicating whether the string is a valid name for a Swift target, file or type.
     var isValidName: Bool {
-        guard !self.isEmpty else { return false }
-        guard let firstChar = self.first, firstChar.isLetter || firstChar == "_" else { return false }
-        return self.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+        self.wholeMatch(of: #/
+            (?:\p{L}|_)         # match Letter or underscore
+            (?:\p{L}|\p{N}|_)*  # match zero or more Letters, Numbers, and/or underscores
+        /#) != nil
     }
 }

--- a/Sources/VaporToolbox/TemplateRenderer.swift
+++ b/Sources/VaporToolbox/TemplateRenderer.swift
@@ -215,7 +215,7 @@ struct TemplateRenderer {
     }
 }
 
-extension StringProtocol {
+extension String {
     var kebabcased: String {
         self
             .split(whereSeparator: { !$0.isLetter })

--- a/Sources/VaporToolbox/TemplateRenderer.swift
+++ b/Sources/VaporToolbox/TemplateRenderer.swift
@@ -26,7 +26,7 @@ struct TemplateRenderer {
         with variables: [String: Any]
     ) throws {
         var context = variables
-        context["name"] = name
+        context["name"] = name.isValidName ? name : name.pascalcased
         context["name_kebab"] = name.kebabcased
 
         if self.verbose { print("name: \(name.colored(.cyan))") }
@@ -221,5 +221,19 @@ extension StringProtocol {
             .split(whereSeparator: { !$0.isLetter })
             .map { $0.lowercased() }
             .joined(separator: "-")
+    }
+
+    var pascalcased: String {
+        self
+            .split(whereSeparator: { !$0.isLetter })
+            .map { $0.capitalized }
+            .joined()
+    }
+
+    /// A Boolean value indicating whether the string is a valid name for a Swift target, file or type.
+    var isValidName: Bool {
+        guard !self.isEmpty else { return false }
+        guard let firstChar = self.first, firstChar.isLetter || firstChar == "_" else { return false }
+        return self.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
     }
 }

--- a/Tests/VaporToolboxTests/VaporToolboxTests.swift
+++ b/Tests/VaporToolboxTests/VaporToolboxTests.swift
@@ -46,10 +46,27 @@ struct VaporToolboxTests {
         }
     }
 
-    @Test("Kebab Cased")
-    func kebabcased() {
-        let string = "Hello, World!"
+    @Test("Kebab Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World"])
+    func kebabcased(_ string: String) {
         #expect(string.kebabcased == "hello-world")
+    }
+
+    @Test("Pascal Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World"])
+    func pascalcased(_ string: String) {
+        #expect(string.pascalcased == "HelloWorld")
+    }
+
+    @Test("Is Valid Name")
+    func isValidName() {
+        let validNames = ["hello_world", "helloWorld", "HelloWorld", "helloWorld123", "__helloWorld_123"]
+        for name in validNames {
+            #expect(name.isValidName)
+        }
+
+        let invalidNames = ["hello world", "hello-world", "hello@world", "hello.world", "hello, world", "21helloWorld", ""]
+        for name in invalidNames {
+            #expect(!name.isValidName)
+        }
     }
 }
 #endif  // canImport(Testing)

--- a/Tests/VaporToolboxTests/VaporToolboxTests.swift
+++ b/Tests/VaporToolboxTests/VaporToolboxTests.swift
@@ -46,19 +46,19 @@ struct VaporToolboxTests {
         }
     }
 
-    @Test("Kebab Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World"])
+    @Test("Kebab Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World", "hello1world"])
     func kebabcased(_ string: String) {
         #expect(string.kebabcased == "hello-world")
     }
 
-    @Test("Pascal Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World"])
+    @Test("Pascal Cased", arguments: ["Hello, World!", "hello-world", "21_hello-World", "hello1world"])
     func pascalcased(_ string: String) {
         #expect(string.pascalcased == "HelloWorld")
     }
 
     @Test("Is Valid Name")
     func isValidName() {
-        let validNames = ["hello_world", "helloWorld", "HelloWorld", "helloWorld123", "__helloWorld_123"]
+        let validNames = ["hello_world", "helloWorld", "HelloWorld", "helloWorld123", "__helloWorld_123", "_123"]
         for name in validNames {
             #expect(name.isValidName)
         }


### PR DESCRIPTION
Fixes issue related to https://github.com/vapor/template/pull/152

The name sanitization is very opinionated, let me know what you think