### PR TITLE
Allow reversing condition to render a file

### DIFF
--- a/Sources/VaporToolbox/TemplateRenderer.swift
+++ b/Sources/VaporToolbox/TemplateRenderer.swift
@@ -162,7 +162,15 @@ struct TemplateRenderer {
     ) throws {
         // If the file has a condition on whether it should be rendered or not
         // check for the condition in the context, including nested variables.
-        if case .exists(let variable) = file.condition {
+        if case .exists(let rawVariable) = file.condition {
+            // Check if the condition starts with "!" to invert the condition
+            var variable = rawVariable
+            var invert = false
+            if variable.hasPrefix("!") {
+                invert = true
+                variable.removeFirst()
+            }
+
             let components = variable.split(separator: ".").map { String($0) }
             var subContext: Any = context
 
@@ -171,11 +179,17 @@ struct TemplateRenderer {
                     let dict = subContext as? [String: Any],
                     let value = dict[component]
                 else {
-                    return
+                    // If here, it means the variable doesn't exist in the context.
+                    // If invert==true, continue to render the file, otherwise return.
+                    if invert { break } else { return }
                 }
 
-                if let bool = value as? Bool, !bool {
-                    return
+                if let bool = value as? Bool {
+                    // If the condition in the manifest doesn't start with "!", `invert` is false,
+                    // so if the value is false, return and don't render the file.
+                    if bool == invert {
+                        return
+                    }
                 }
 
                 subContext = value

--- a/Tests/VaporToolboxTests/manifest.json
+++ b/Tests/VaporToolboxTests/manifest.json
@@ -250,6 +250,10 @@
           {
             "file": "vapor.code-snippets",
             "if": "vscode.snippets"
+          },
+          {
+            "file": "extensions.json",
+            "if": "!vscode.snippets"
           }
         ]
       },

--- a/Tests/VaporToolboxTests/manifest.yml
+++ b/Tests/VaporToolboxTests/manifest.yml
@@ -141,6 +141,8 @@ files:
     if: vscode
     files:
       - file: vapor.code-snippets
-        if: vscode.snippets
+        if: vscode.snippets # Nested condition
+      - file: extensions.json
+        if: "!vscode.snippets" # Inverse condition
   - .gitignore
   - .dockerignore


### PR DESCRIPTION
Check for a `!` at the start of the `if:` condition to render a file, in which case it reverses the condition.