### PR TITLE
Add instructions to run the toolbox using Mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ vapor --help
 
 You should see a list of available commands.
 
+#### Mise
+
+You can also use [Mise](https://mise.jdx.dev) to install the toolbox and create a new project. Mise will compile the toolbox from the sources:
+
+```bash
+mise x spm:vapor/toolbox@latest -- vapor new Hello -n
+```
+
 ## Overview
 
 The Vapor Toolbox is a command line tool that helps you create new Vapor projects.


### PR DESCRIPTION
[Mise](https://mise.jdx.dev) is a tool to manage development environments and it has support for installing and running SwiftPM-built executables like the Vapor Toolbox. Therefore, I thought it'd be useful for people to have the instructions in the README about how to run the toolbox through Mise.