### PR TITLE
Fix crash when defining both parent and nested flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:6.1-jammy as build
+FROM swift:6.2-jammy as build
 WORKDIR /build
 COPY . .
 RUN swift build --build-path /build/.build --static-swift-stdlib -c release

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install: build
 	$(_USE_SUDO) chmod 755 ${DEST}
 # Install manpage
 	$(_USE_SUDO) mkdir -p $(MANDEST_DIR)
-	$(_USE_SUDO) cp .build/plugins/GenerateManual/outputs/vapor/vapor.1 $(MANDEST_DIR)/vapor.1
+	$(_USE_SUDO) cp .build/plugins/GenerateManual/outputs/VaporToolbox/vapor.1 $(MANDEST_DIR)/vapor.1
 uninstall:
 	$(_USE_SUDO) rm ${DEST}
 # Remove manpage

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "494c7a8e46c08438fd53741568f52b4446b0859eb6e2a667f6de1d12ac9f0cea",
+  "originHash" : "78ed5daaccd9fa29e933e437fb4bb47d9fadbd047e0327e8ab29849d61f13398",
   "pins" : [
     {
       "identity" : "console-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "774e9c8a918ea1587b545db1d03293be8882a393",
-        "version" : "5.0.0-alpha.1"
+        "revision" : "ebd3ee6f857eb78ed2ab34a23ec72ff81d3fd9a4",
+        "version" : "5.0.0-beta.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
-        "version" : "1.6.2"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -33,8 +33,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {
@@ -42,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -51,8 +60,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/swift-mustache.git",
       "state" : {
-        "revision" : "2e2a84698dd8a5fff2fe28857f0f95bb03d21d64",
-        "version" : "2.0.2"
+        "revision" : "0b91b3127baee1d97c45a7390a49779256b4295d",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -60,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-subprocess.git",
       "state" : {
-        "revision" : "44922dfe46380cd354ca4b0208e717a3e92b13dd",
-        "version" : "0.2.1"
+        "revision" : "40243d063b41485e17501ccb9d434006bdf837a5",
+        "version" : "1.0.0-beta.1"
       }
     },
     {
@@ -78,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "51b5127c7fb6ffac106ad6d199aaa33c5024895f",
-        "version" : "6.2.0"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
@@ -10,11 +10,11 @@ let package = Package(
         .executable(name: "vapor", targets: ["VaporToolbox"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.2"),
-        .package(url: "https://github.com/vapor/console-kit.git", exact: "5.0.0-alpha.1"),
-        .package(url: "https://github.com/swiftlang/swift-subprocess.git", .upToNextMinor(from: "0.2.1")),
-        .package(url: "https://github.com/hummingbird-project/swift-mustache.git", from: "2.0.2"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.2"),
+        .package(url: "https://github.com/vapor/console-kit.git", exact: "5.0.0-beta.1"),
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", exact: "1.0.0-beta.1"),
+        .package(url: "https://github.com/hummingbird-project/swift-mustache.git", from: "2.1.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "6.2.2"),
     ],
     targets: [
         .executableTarget(
@@ -52,6 +52,10 @@ let package = Package(
 var swiftSettings: [SwiftSetting] {
     [
         .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
         .enableUpcomingFeature("MemberImportVisibility"),
+        .enableUpcomingFeature("InferIsolatedConformances"),
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+        .enableUpcomingFeature("ImmutableWeakCaptures"),
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-<p align="center">
-    <img 
-        src="https://user-images.githubusercontent.com/1342803/87364900-cf9e6880-c542-11ea-9cdf-9621a11925e1.png" 
-        height="64" 
-        alt="Vapor Toolbox"
-    >
-    <br>
-    <br>
-    <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
-    <a href="https://discord.gg/vapor"><img src="https://design.vapor.codes/images/discordchat.svg" alt="Team Chat"></a>
-    <a href="LICENSE.txt"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
-    <a href="https://github.com/vapor/toolbox/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/toolbox/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="CI"></a>
-    <a href="https://codecov.io/github/vapor/toolbox"><img src="https://img.shields.io/codecov/c/github/vapor/toolbox?style=plastic&logo=codecov&label=codecov"></a>
-    <a href="https://swift.org"><img src="https://design.vapor.codes/images/swift62up.svg" alt="Swift 6.2"></a>
-</p>
+<div align="center">
+<img src="https://design.vapor.codes/images/vapor-toolbox.svg" height="96" alt="Vapor Toolbox">
+<br>
+
+[![Documentation](https://design.vapor.codes/images/readthedocs.svg)](https://docs.vapor.codes/4.0/)
+[![Team Chat](https://design.vapor.codes/images/discordchat.svg)](https://discord.gg/vapor)
+[![MIT License](https://design.vapor.codes/images/mitlicense.svg)](./LICENSE.txt)
+[![CI](https://img.shields.io/github/actions/workflow/status/vapor/toolbox/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=ccc)](https://github.com/vapor/toolbox/actions/workflows/test.yml)
+[![Code Coverage](https://img.shields.io/codecov/c/github/vapor/toolbox?style=plastic&logo=codecov&label=codecov)](https://codecov.io/github/vapor/toolbox)
+[![Swift 6.2](https://design.vapor.codes/images/swift62up.svg)](https://swift.org)
+
+</div>
 
 🧰 A CLI tool to easily create new Vapor projects.
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
     <a href="LICENSE.txt"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
     <a href="https://github.com/vapor/toolbox/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/toolbox/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="CI"></a>
     <a href="https://codecov.io/github/vapor/toolbox"><img src="https://img.shields.io/codecov/c/github/vapor/toolbox?style=plastic&logo=codecov&label=codecov"></a>
-    <a href="https://swift.org"><img src="https://design.vapor.codes/images/swift61up.svg" alt="Swift 6.1"></a>
+    <a href="https://swift.org"><img src="https://design.vapor.codes/images/swift62up.svg" alt="Swift 6.2"></a>
 </p>
 
 🧰 A CLI tool to easily create new Vapor projects.
 
 ### Supported Platforms
 
-Vapor Toolbox supports macOS 15.0+ and all Linux distributions that Swift 6.1 supports.
+Vapor Toolbox supports macOS 15.0+ and all Linux distributions that Swift 6.2 supports.
 
 ### Installation
 

--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -281,7 +281,7 @@ extension Vapor.New: CustomReflectable {
         func decodeVariable(_ variable: TemplateManifest.Variable, path: String) throws -> Any? {
             switch variable.type {
             case .bool:
-                return try container.decode(Flag.self, forKey: .dynamic(path)).wrappedValue
+                return try container.decode(Flag<Bool>.self, forKey: .dynamic(path)).wrappedValue
             case .string:
                 return try container.decodeIfPresent(Option<String>.self, forKey: .dynamic(path))?.wrappedValue
             case .options(let options):
@@ -291,6 +291,7 @@ extension Vapor.New: CustomReflectable {
                 else { return nil }
                 return option.data
             case .variables(let nestedVars):
+                let parentFlag = try container.decodeIfPresent(Flag<Bool>.self, forKey: .dynamic(path))?.wrappedValue
                 var nested: [String: Any] = [:]
 
                 // Decode all nested variables first
@@ -300,9 +301,13 @@ extension Vapor.New: CustomReflectable {
                     }
                 }
 
+                if parentFlag == false, !nested.isEmpty {
+                    throw ValidationError("Cannot pass nested options for --\(path) when --no-\(path) is set.")
+                }
+
                 // If there are no nested variables, check the parent flag
                 if nested.isEmpty {
-                    if let parentFlag = try container.decodeIfPresent(Flag<Bool>.self, forKey: .dynamic(path))?.wrappedValue {
+                    if let parentFlag {
                         return parentFlag ? [:] : false
                     } else {
                         return nil

--- a/Sources/VaporToolbox/VaporToolbox.docc/vapor.md
+++ b/Sources/VaporToolbox/VaporToolbox.docc/vapor.md
@@ -18,7 +18,8 @@ vapor [--help]
 Generates a new app.
 
 ```
-vapor new <name> [--template=<url>] [--branch=<branch>] [--manifest=<file>] [--output=<path>] [--no-commit] [--no-git] [--yes] [--no] [--verbose]  [--help]
+vapor new <name> [--template=<url>] [--branch=<branch>] [--manifest=<file>]
+  [--output=<path>] [--no-commit] [--no-git] [--yes] [--no] [--verbose] [--help]
 ```
 
 **name:**
@@ -83,7 +84,7 @@ vapor new <name> [--template=<url>] [--branch=<branch>] [--manifest=<file>] [--o
 Show subcommand help information.
 
 ```
-vapor help [<subcommands>...] 
+vapor help [<subcommands>...]
 ```
 
 **subcommands:**

--- a/Tests/VaporToolboxTests/BuildToolboxTests.swift
+++ b/Tests/VaporToolboxTests/BuildToolboxTests.swift
@@ -23,7 +23,7 @@ struct BuildToolboxTests {
         #expect(version.contains(branchAndCommit) || version.contains(semver))
     }
 
-    @Test("Update Version.swift File", arguments: [true, false])
+    @Test("Update Version.swift File", .serialized, arguments: [true, false])
     func withVersion(operationThrows: Bool) async throws {
         let file = URL(filePath: #filePath).deletingLastPathComponent().appending(path: "TestingVersion.swift")
         let originalFileContents: String = try String(contentsOf: file, encoding: .utf8)

--- a/Tests/VaporToolboxTests/VaporToolboxTests.swift
+++ b/Tests/VaporToolboxTests/VaporToolboxTests.swift
@@ -1,3 +1,4 @@
+import ArgumentParser
 import Testing
 import Yams
 
@@ -11,18 +12,72 @@ import Foundation
 
 @Suite("Vapor Toolbox Tests")
 struct VaporToolboxTests {
-    #if !os(Android)
-    @Test("Vapor.preprocess")
-    func preprocess() async throws {
-        #expect(Vapor.manifest == nil)
-        try await Vapor.preprocess([])
-        #expect(Vapor.manifest != nil)
-    }
-    #endif
-
     @Test("Vapor.version")
     func version() async {
         #expect(await Vapor.version.contains("toolbox: "))
+    }
+
+    /// These tests modify the global `Vapor.manifest` variable,
+    /// so they must be serialized to avoid race conditions.
+    @Suite("Vapor.manifest Tests", .serialized)
+    struct VaporManifestTests {
+        #if !os(Android)
+        @Test("Vapor.preprocess")
+        func preprocess() async throws {
+            defer { Vapor.manifest = nil }
+
+            #expect(Vapor.manifest == nil)
+            try await Vapor.preprocess([])
+            #expect(Vapor.manifest != nil)
+        }
+        #endif
+
+        @Test("New command parses nested flag and nested options", arguments: [["--fluent"], []])
+        func parseNestedOptions(flags: [String]) throws {
+            defer { Vapor.manifest = nil }
+
+            let manifestJSON = #"""
+                {
+                    "name": "Testing Vapor Template",
+                    "variables": [
+                        {
+                            "name": "fluent",
+                            "description": "Would you like to use Fluent (ORM)?",
+                            "type": "nested",
+                            "variables": [
+                                {
+                                    "name": "db",
+                                    "description": "Which database would you like to use?",
+                                    "type": "option",
+                                    "options": [
+                                        { "name": "Postgres", "data": { "id": "psql" } },
+                                        { "name": "MySQL", "data": { "id": "mysql" } },
+                                        { "name": "SQLite", "data": { "id": "sqlite" } }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "leaf",
+                            "description": "Would you like to use Leaf (templating)?",
+                            "type": "bool"
+                        }
+                    ],
+                    "files": []
+                }
+                """#
+            Vapor.manifest = try JSONDecoder().decode(TemplateManifest.self, from: Data(manifestJSON.utf8))
+
+            let command = try #require(
+                Vapor.New.parseAsRoot(["PersonalSite", "--fluent.db", "MySQL", "--leaf"] + flags) as? Vapor.New
+            )
+
+            let fluent = command.variables["fluent"] as? [String: Any]
+            let fluentDB = fluent?["db"] as? [String: String]
+
+            #expect(fluentDB?["id"] == "mysql")
+            #expect(command.variables["leaf"] as? Bool == true)
+        }
     }
 
     #if !os(Android)


### PR DESCRIPTION
**These changes are now available in [20.0.1](https://github.com/vapor/toolbox/releases/tag/20.0.1)**


For example, when running
```sh
vapor new PersonalSite --fluent --fluent.db MySQL --leaf
```
it used to fail because the parent flag was decoded only if there were no nested flag. Now we decode it always.

Also updates dependencies and improves tests