### PR TITLE
Fix crash when boolean flag isn't specified

### DIFF
--- a/Sources/VaporToolbox/New.swift
+++ b/Sources/VaporToolbox/New.swift
@@ -281,7 +281,7 @@ extension Vapor.New: CustomReflectable {
         func decodeVariable(_ variable: TemplateManifest.Variable, path: String) throws -> Any? {
             switch variable.type {
             case .bool:
-                return try container.decode(Flag<Bool>.self, forKey: .dynamic(path)).wrappedValue
+                return try container.decode(Flag.self, forKey: .dynamic(path)).wrappedValue
             case .string:
                 return try container.decodeIfPresent(Option<String>.self, forKey: .dynamic(path))?.wrappedValue
             case .options(let options):

--- a/Tests/VaporToolboxTests/VaporToolboxTests.swift
+++ b/Tests/VaporToolboxTests/VaporToolboxTests.swift
@@ -69,14 +69,14 @@ struct VaporToolboxTests {
             Vapor.manifest = try JSONDecoder().decode(TemplateManifest.self, from: Data(manifestJSON.utf8))
 
             let command = try #require(
-                Vapor.New.parseAsRoot(["PersonalSite", "--fluent.db", "MySQL", "--leaf"] + flags) as? Vapor.New
+                Vapor.New.parseAsRoot(["PersonalSite", "--fluent.db", "MySQL"] + flags) as? Vapor.New
             )
 
             let fluent = command.variables["fluent"] as? [String: Any]
             let fluentDB = fluent?["db"] as? [String: String]
 
             #expect(fluentDB?["id"] == "mysql")
-            #expect(command.variables["leaf"] as? Bool == true)
+            #expect(command.variables["leaf"] as? Bool == nil)
         }
     }
 


### PR DESCRIPTION
**These changes are now available in [20.0.2](https://github.com/vapor/toolbox/releases/tag/20.0.2)**


If a boolean flag like `--leaf` or `--no-leaf` isn't specified, the CLI crashes.

This reverts the behavior for boolean flags as it was before #493.

This doesn't change the behavior for nested flag, which were the main objectives of the previous PR.